### PR TITLE
refactor: to `timezone` specific `datetime` helpers to avoid use deprecated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## 0.5.0 [unreleased]
 
+### Bug Fixes
+
+1. [#86](https://github.com/InfluxCommunity/influxdb3-python/pull/86): Refactor to `timezone` specific `datetime` helpers to avoid use deprecated functions
+
 ### Others
 
-- [#84](https://github.com/InfluxCommunity/influxdb3-python/pull/84): Enable packaging type information - `py.typed`
+1. [#84](https://github.com/InfluxCommunity/influxdb3-python/pull/84): Enable packaging type information - `py.typed`
 
 ## 0.4.0 [2024-04-17]
 

--- a/influxdb_client_3/write_client/client/write/point.py
+++ b/influxdb_client_3/write_client/client/write/point.py
@@ -10,7 +10,7 @@ from numbers import Integral
 from influxdb_client_3.write_client.client.util.date_utils import get_date_helper
 from influxdb_client_3.write_client.domain.write_precision import WritePrecision
 
-EPOCH = datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
+EPOCH = datetime.fromtimestamp(0, tz=timezone.utc)
 
 DEFAULT_WRITE_PRECISION = WritePrecision.NS
 

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,0 +1,10 @@
+import datetime
+import unittest
+
+from influxdb_client_3.write_client.client.write.point import EPOCH
+
+
+class TestPoint(unittest.TestCase):
+
+    def test_epoch(self):
+        self.assertEqual(EPOCH, datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc))

--- a/tests/test_point.py
+++ b/tests/test_point.py
@@ -1,10 +1,14 @@
 import datetime
 import unittest
 
-from influxdb_client_3.write_client.client.write.point import EPOCH
+from influxdb_client_3.write_client.client.write.point import EPOCH, Point
 
 
 class TestPoint(unittest.TestCase):
 
     def test_epoch(self):
         self.assertEqual(EPOCH, datetime.datetime(1970, 1, 1, 0, 0, tzinfo=datetime.timezone.utc))
+
+    def test_point(self):
+        point = Point.measurement("h2o").tag("location", "europe").field("level", 2.2).time(1_000_000)
+        self.assertEqual('h2o,location=europe level=2.2 1000000', point.to_line_protocol())


### PR DESCRIPTION
## Proposed Changes

![image](https://github.com/influxdata/influxdb-client-python/assets/455137/75982ef8-f743-4d75-b808-5aea27978db3)
![image](https://github.com/influxdata/influxdb-client-python/assets/455137/26771d81-1139-4c2f-86dc-20f4f57828af)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
