### PR TITLE
fix: Use correct write_options parameter in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+<!-- markdownlint-disable MD024 -->
+# Change Log
+
 ## 0.5.0 [unreleased]
+
+### Bugfix
+
+- [#87](https://github.com/InfluxCommunity/influxdb3-python/pull/87): Fix examples to use `write_options` instead of the object name `WriteOptions`
 
 ### Others
 

--- a/Examples/batching_example.py
+++ b/Examples/batching_example.py
@@ -49,7 +49,7 @@ write_options = WriteOptions(batch_size=5_000,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 # Opening InfluxDB client with a batch size of 5k points or flush interval
 # of 10k ms and gzip compression

--- a/Examples/community/custom_url.py
+++ b/Examples/community/custom_url.py
@@ -30,7 +30,7 @@ write_options = WriteOptions(batch_size=100,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 client = InfluxDBClient3(

--- a/Examples/community/database_transfer.py
+++ b/Examples/community/database_transfer.py
@@ -38,7 +38,7 @@ write_options = WriteOptions(batch_size=5_000,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 # Opening InfluxDB client with a batch size of 5k points or flush interval
 # of 10k ms and gzip compression

--- a/Examples/file-import/csv_write.py
+++ b/Examples/file-import/csv_write.py
@@ -27,7 +27,7 @@ write_options = WriteOptions(batch_size=500,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 with InfluxDBClient3.InfluxDBClient3(

--- a/Examples/file-import/feather_write.py
+++ b/Examples/file-import/feather_write.py
@@ -27,7 +27,7 @@ write_options = WriteOptions(batch_size=500,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 with InfluxDBClient3.InfluxDBClient3(

--- a/Examples/file-import/json_write.py
+++ b/Examples/file-import/json_write.py
@@ -27,7 +27,7 @@ write_options = WriteOptions(batch_size=500,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 with InfluxDBClient3.InfluxDBClient3(

--- a/Examples/file-import/orc_write.py
+++ b/Examples/file-import/orc_write.py
@@ -27,7 +27,7 @@ write_options = WriteOptions(batch_size=500,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 with InfluxDBClient3.InfluxDBClient3(

--- a/Examples/file-import/parquet_write.py
+++ b/Examples/file-import/parquet_write.py
@@ -27,7 +27,7 @@ write_options = WriteOptions(batch_size=500,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 with InfluxDBClient3.InfluxDBClient3(

--- a/Examples/file-import/write_file_parse_options.py
+++ b/Examples/file-import/write_file_parse_options.py
@@ -27,7 +27,7 @@ write_options = WriteOptions(batch_size=500,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 with InfluxDBClient3.InfluxDBClient3(

--- a/Examples/pokemon-trainer/cookbook.ipynb
+++ b/Examples/pokemon-trainer/cookbook.ipynb
@@ -19,7 +19,7 @@
    "outputs": [],
    "source": [
     "\n",
-    "# Here we include all the imports required from influxdb_client_3 \n",
+    "# Here we include all the imports required from influxdb_client_3\n",
     "from influxdb_client_3 import InfluxDBClient3, InfluxDBError, WriteOptions, write_client_options\n",
     "import pandas as pd\n",
     "import random"
@@ -75,7 +75,7 @@
     "wco = write_client_options(success_callback=callback.success,\n",
     "                          error_callback=callback.error,\n",
     "                          retry_callback=callback.retry,\n",
-    "                          WriteOptions=write_options \n",
+    "                          write_options=write_options\n",
     "                        )"
    ]
   },
@@ -655,7 +655,7 @@
     "query = '''SHOW COLUMNS FROM caught'''\n",
     "\n",
     "# We can use the query method to run a query against the database.\n",
-    "# Under the hood this creates a flight ticket and uses the FlightClient to run the query. \n",
+    "# Under the hood this creates a flight ticket and uses the FlightClient to run the query.\n",
     "# For this example we are using the pandas mode, which will return a pandas DataFrame.\n",
     "# Language also allows us to specify the query language, in this case we are using SQL.\n",
     "table = client.query(query=query, language='sql', mode='pandas')\n",
@@ -1702,7 +1702,7 @@
     "query = '''SELECT count(\"name\") FROM caught WHERE time > now() - 1h GROUP BY trainer'''\n",
     "\n",
     "# We can use the query method to run a query against the database.\n",
-    "# Under the hood this creates a flight ticket and uses the FlightClient to run the query. \n",
+    "# Under the hood this creates a flight ticket and uses the FlightClient to run the query.\n",
     "# For this example we are using the pandas mode, which will return a pandas DataFrame.\n",
     "# Language also allows us to specify the query language, in this case we are using SQL.\n",
     "table = client.query(query=query, language='influxql', mode='pandas')\n",
@@ -3104,7 +3104,7 @@
     "query = '''SELECT count(\"name\") FROM caught WHERE time > now() - 1h GROUP BY trainer,type1'''\n",
     "\n",
     "# We can use the query method to run a query against the database.\n",
-    "# Under the hood this creates a flight ticket and uses the FlightClient to run the query. \n",
+    "# Under the hood this creates a flight ticket and uses the FlightClient to run the query.\n",
     "# For this example we are using the pandas mode, which will return a pandas DataFrame.\n",
     "# Language also allows us to specify the query language, in this case we are using SQL.\n",
     "table = client.query(query=query, language='influxql' , mode='pandas')\n",

--- a/Examples/pokemon-trainer/write-batching-flight-calloptions.py
+++ b/Examples/pokemon-trainer/write-batching-flight-calloptions.py
@@ -33,7 +33,7 @@ write_options = WriteOptions(batch_size=100,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 client = InfluxDBClient3(

--- a/Examples/pokemon-trainer/write-batching.py
+++ b/Examples/pokemon-trainer/write-batching.py
@@ -30,7 +30,7 @@ write_options = WriteOptions(batch_size=100,
 wco = write_client_options(success_callback=callback.success,
                            error_callback=callback.error,
                            retry_callback=callback.retry,
-                           WriteOptions=write_options
+                           write_options=write_options
                            )
 
 client = InfluxDBClient3(

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 - `pyarrow` (automatically installed)
 - `pandas` (optional)
-  
+
 
 ## Installation
 
@@ -113,7 +113,7 @@ write_options = WriteOptions(batch_size=500,
 wco = write_client_options(success_callback=callback.success,
                           error_callback=callback.error,
                           retry_callback=callback.retry,
-                          WriteOptions=write_options 
+                          write_options=write_options
                         )
 
 with  InfluxDBClient3.InfluxDBClient3(
@@ -126,11 +126,11 @@ with  InfluxDBClient3.InfluxDBClient3(
     client.write_file(
         file='./out.csv',
         timestamp_column='time', tag_columns=["provider", "machineID"])
-    
+
     client.write_file(
         file='./out.json',
         timestamp_column='time', tag_columns=["provider", "machineID"], date_unit='ns' )
-    
+
 
 ```
 
@@ -144,7 +144,7 @@ client._write_api.write(bucket="pokemon-codex", record=pd_df, data_frame_measure
 client._write_api.write(bucket="pokemon-codex", record=pl_df, data_frame_measurement_name='caught', data_frame_tag_columns=['trainer', 'id', 'num'], data_frame_timestamp_column='timestamp')
 ```
 
-## Querying 
+## Querying
 
 ### Querying with SQL
 ```python
@@ -196,4 +196,4 @@ table = client.query(
 
 print(table.to_pandas())
 ```
-You may also include your own root certificate via this manor aswell. 
+You may also include your own root certificate via this manor aswell.


### PR DESCRIPTION
WriteOptions is the object, but the parameter is expected to be write_options.

fixes: #79 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
