### PR TITLE
feat: use build-in Python parsing feature for python >= 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
             pip install . --user
             pip install .\[dataframe\] --user
             pip install .\[test\] --user
-            pytest -m "<< parameters.pytest-marker >>" tests --junitxml=test-reports/junit.xml --cov=./ --cov-report xml:coverage.xml
+            pytest -m "<< parameters.pytest-marker >>" tests --junitxml=test-reports/junit.xml --cov=./influxdb_client_3 --cov-report xml:coverage.xml
       - save_cache:
           name: Saving Pip Cache
           key: *cache-key

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pyinflux3*.egg-info
 __pycache__
 .idea
 *.egg-info/
+.coverage
+coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.6.0 [unreleased]
 
+### Features
+1. [#89](https://github.com/InfluxCommunity/influxdb3-python/pull/89): Use `datetime.fromisoformat` over `dateutil.parse` in Python 3.11+
+
 ## 0.5.0 [2024-05-17]
 
 ### Features

--- a/influxdb_client_3/write_client/client/util/date_utils.py
+++ b/influxdb_client_3/write_client/client/util/date_utils.py
@@ -2,6 +2,7 @@
 import datetime
 import threading
 from datetime import timezone as tz
+from sys import version_info
 
 from dateutil import parser
 
@@ -90,7 +91,10 @@ def get_date_helper() -> DateHelper:
                     import ciso8601
                     _date_helper.parse_date = ciso8601.parse_datetime
                 except ModuleNotFoundError:
-                    _date_helper.parse_date = parser.parse
+                    if (version_info.major, version_info.minor) >= (3, 11):
+                        _date_helper.parse_date = datetime.datetime.fromisoformat
+                    else:
+                        _date_helper.parse_date = parser.parse
                 date_helper = _date_helper
 
     return date_helper

--- a/tests/test_date_helper.py
+++ b/tests/test_date_helper.py
@@ -6,7 +6,7 @@ from dateutil import tz
 from influxdb_client_3.write_client.client.util.date_utils import DateHelper, get_date_helper
 
 
-class DateHelperTest(unittest.TestCase):
+class TestDateHelper(unittest.TestCase):
 
     def test_to_utc(self):
         date = get_date_helper().to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))

--- a/tests/test_date_helper.py
+++ b/tests/test_date_helper.py
@@ -1,0 +1,21 @@
+import unittest
+from datetime import datetime, timezone
+
+from dateutil import tz
+
+from influxdb_client_3.write_client.client.util.date_utils import DateHelper, get_date_helper
+
+
+class DateHelperTest(unittest.TestCase):
+
+    def test_to_utc(self):
+        date = get_date_helper().to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))
+        self.assertEqual(datetime(2021, 4, 29, 20, 30, 10, 0, timezone.utc), date)
+
+    def test_to_utc_different_timezone(self):
+        date = DateHelper(timezone=tz.gettz('ETC/GMT+2')).to_utc(datetime(2021, 4, 29, 20, 30, 10, 0))
+        self.assertEqual(datetime(2021, 4, 29, 22, 30, 10, 0, timezone.utc), date)
+
+    def test_parse(self):
+        date = get_date_helper().parse_date("2021-03-20T15:59:10.607352Z")
+        self.assertEqual(datetime(2021, 3, 20, 15, 59, 10, 607352, timezone.utc), date)

--- a/tests/test_merge_options.py
+++ b/tests/test_merge_options.py
@@ -3,7 +3,7 @@ import unittest
 import influxdb_client_3
 
 
-class MergeOptionsTests(unittest.TestCase):
+class TestMergeOptions(unittest.TestCase):
 
     def test_merge_with_empty_custom(self):
         defaults = {"a": 1, "b": 2}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -6,7 +6,7 @@ from pyarrow.flight import Ticket
 from influxdb_client_3 import InfluxDBClient3
 
 
-class QueryTests(unittest.TestCase):
+class TestQuery(unittest.TestCase):
 
     @patch('influxdb_client_3._InfluxDBClient')
     @patch('influxdb_client_3._WriteApi')


### PR DESCRIPTION
## Proposed Changes

Use build-in date parsing feature. From version 3.11 the performance is same as for ciso8601.

For more info see - https://github.com/influxdata/influxdb-client-python/pull/657

![image](https://github.com/InfluxCommunity/influxdb3-python/assets/455137/3e554aad-2dbe-4c2b-9bea-283d4c535033)

https://docs.python.org/3/library/datetime.html#datetime.date.fromisoformat

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
