### PR TITLE
fix: missing module declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.7.0 [unreleased]
 
+### Bug Fixes
+
+1. [#98](https://github.com/InfluxCommunity/influxdb3-python/pull/98): Missing declaration for `query` module
+
 ## 0.6.0 [2024-06-24]
 
 ### Features

--- a/influxdb_client_3/query/__init__.py
+++ b/influxdb_client_3/query/__init__.py
@@ -1,0 +1,1 @@
+"""Package for query module."""


### PR DESCRIPTION
Closes #97 

## Proposed Changes

Added missing module declaration for Query module.

## Tested by

```console
mkdir missing_module
cd missing_module

python -m venv ./.venv  
source .venv/bin/activate
pip install git+https://github.com/InfluxCommunity/influxdb3-python@query-package
python -c 'from influxdb_client_3 import InfluxDBClient3, Point'
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
