### PR TITLE
fix: handle Edge errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## 0.8.0 [unreleased]
 
+### Bug Fixes
+
+1. [#100](https://github.com/InfluxCommunity/influxdb3-python/pull/100): InfluxDB Edge (OSS) error handling
+
 ## 0.7.0 [2024-07-11]
 
 ### Bug Fixes
 
 1. [#95](https://github.com/InfluxCommunity/influxdb3-python/pull/95): `Polars` is optional dependency
 1. [#99](https://github.com/InfluxCommunity/influxdb3-python/pull/99): Skip infinite values during serialization to line protocol
-1. [#100](https://github.com/InfluxCommunity/influxdb3-python/pull/100): InfluxDB Edge (OSS) error handling
 
 ## 0.6.1 [2024-06-25]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 1. [#95](https://github.com/InfluxCommunity/influxdb3-python/pull/95): `Polars` is optional dependency
 1. [#99](https://github.com/InfluxCommunity/influxdb3-python/pull/99): Skip infinite values during serialization to line protocol
+1. [#100](https://github.com/InfluxCommunity/influxdb3-python/pull/100): InfluxDB Edge (OSS) error handling
 
 ## 0.6.1 [2024-06-25]
 

--- a/influxdb_client_3/write_client/client/exceptions.py
+++ b/influxdb_client_3/write_client/client/exceptions.py
@@ -33,13 +33,10 @@ class InfluxDBError(Exception):
                 return get(d.get(key[0]), key[1:])
             try:
                 node = json.loads(response.data)
-                print(type(node))
                 for key in [['message'], ['data', 'error_message'], ['error']]:
                     value = get(node, key)
-                    print('YYY has {0} ? {1} ({2})'.format(key, value is not None, value))
                     if value is not None:
                         return value
-                print("YYY fallback to data")
                 return response.data
             except Exception as e:
                 logging.debug(f"Cannot parse error response to JSON: {response.data}, {e}")

--- a/influxdb_client_3/write_client/client/exceptions.py
+++ b/influxdb_client_3/write_client/client/exceptions.py
@@ -26,8 +26,21 @@ class InfluxDBError(Exception):
         # Body
         if response.data:
             import json
+
+            def get(d, key):
+                if not key or d is None:
+                    return d
+                return get(d.get(key[0]), key[1:])
             try:
-                return json.loads(response.data)["message"]
+                node = json.loads(response.data)
+                print(type(node))
+                for key in [['message'], ['data', 'error_message'], ['error']]:
+                    value = get(node, key)
+                    print('YYY has {0} ? {1} ({2})'.format(key, value is not None, value))
+                    if value is not None:
+                        return value
+                print("YYY fallback to data")
+                return response.data
             except Exception as e:
                 logging.debug(f"Cannot parse error response to JSON: {response.data}, {e}")
                 return response.data

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -87,7 +87,13 @@ class ApiClientTests(unittest.TestCase):
             self._test_api_error(response_body)
         self.assertEqual('parsing failed for write_lp endpoint', err.exception.message)
 
-    def test_api_error_oss(self):
+    def test_api_error_oss_without_detail(self):
+        response_body = '{"error": "parsing failed for write_lp endpoint"}'
+        with self.assertRaises(InfluxDBError) as err:
+            self._test_api_error(response_body)
+        self.assertEqual('parsing failed for write_lp endpoint', err.exception.message)
+
+    def test_api_error_oss_with_detail(self):
         response_body = ('{"error":"parsing failed for write_lp endpoint","data":{"error_message":"invalid field value '
                          'in line protocol for field \'val\' on line 1"}}')
         with self.assertRaises(InfluxDBError) as err:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -83,25 +83,19 @@ class ApiClientTests(unittest.TestCase):
 
     def test_api_error_cloud(self):
         response_body = '{"message": "parsing failed for write_lp endpoint"}'
-        try:
+        with self.assertRaises(InfluxDBError) as err:
             self._test_api_error(response_body)
-            self.fail("expected InfluxDBError")
-        except InfluxDBError as e:
-            self.assertEqual('parsing failed for write_lp endpoint', e.message)
+        self.assertEqual('parsing failed for write_lp endpoint', err.exception.message)
 
     def test_api_error_oss(self):
         response_body = ('{"error":"parsing failed for write_lp endpoint","data":{"error_message":"invalid field value '
                          'in line protocol for field \'val\' on line 1"}}')
-        try:
+        with self.assertRaises(InfluxDBError) as err:
             self._test_api_error(response_body)
-            self.fail("expected InfluxDBError")
-        except InfluxDBError as e:
-            self.assertEqual('invalid field value in line protocol for field \'val\' on line 1', e.message)
+        self.assertEqual('invalid field value in line protocol for field \'val\' on line 1', err.exception.message)
 
     def test_api_error_unknown(self):
         response_body = '{"detail":"no info"}'
-        try:
+        with self.assertRaises(InfluxDBError) as err:
             self._test_api_error(response_body)
-            self.fail("expected InfluxDBError")
-        except InfluxDBError as e:
-            self.assertEqual(response_body, e.message)
+        self.assertEqual(response_body, err.exception.message)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -97,3 +97,11 @@ class ApiClientTests(unittest.TestCase):
             self.fail("expected InfluxDBError")
         except InfluxDBError as e:
             self.assertEqual('invalid field value in line protocol for field \'val\' on line 1', e.message)
+
+    def test_api_error_unknown(self):
+        response_body = '{"detail":"no info"}'
+        try:
+            self._test_api_error(response_body)
+            self.fail("expected InfluxDBError")
+        except InfluxDBError as e:
+            self.assertEqual(response_body, e.message)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,11 +1,12 @@
 import unittest
 from unittest import mock
+from urllib3 import response
 
 from influxdb_client_3.write_client._sync.api_client import ApiClient
 from influxdb_client_3.write_client.configuration import Configuration
+from influxdb_client_3.write_client.client.exceptions import InfluxDBError
 from influxdb_client_3.write_client.service import WriteService
 from influxdb_client_3.version import VERSION
-
 
 _package = "influxdb3-python"
 _sentHeaders = {}
@@ -69,3 +70,30 @@ class ApiClientTests(unittest.TestCase):
         self.assertEqual("Bearer TEST_TOKEN", _sentHeaders["Authorization"])
         self.assertIsNotNone(_sentHeaders["User-Agent"])
         self.assertEqual(f"{_package}/{VERSION}", _sentHeaders["User-Agent"])
+
+    def _test_api_error(self, body):
+        conf = Configuration()
+        client = ApiClient(conf)
+        client.rest_client.pool_manager.request \
+            = mock.Mock(return_value=response.HTTPResponse(status=400,
+                                                           reason='Bad Request',
+                                                           body=body.encode()))
+        service = WriteService(client)
+        service.post_write("TEST_ORG", "TEST_BUCKET", "data,foo=bar val=3.14")
+
+    def test_api_error_cloud(self):
+        response_body = '{"message": "parsing failed for write_lp endpoint"}'
+        try:
+            self._test_api_error(response_body)
+            self.fail("expected InfluxDBError")
+        except InfluxDBError as e:
+            self.assertEqual('parsing failed for write_lp endpoint', e.message)
+
+    def test_api_error_oss(self):
+        response_body = ('{"error":"parsing failed for write_lp endpoint","data":{"error_message":"invalid field value '
+                         'in line protocol for field \'val\' on line 1"}}')
+        try:
+            self._test_api_error(response_body)
+            self.fail("expected InfluxDBError")
+        except InfluxDBError as e:
+            self.assertEqual('invalid field value in line protocol for field \'val\' on line 1', e.message)


### PR DESCRIPTION
## Proposed Changes

Extends error response processing to handle Edge (OSS) errors as well. It sets `InfluxDBError.message` value from either `message` (Cloud) or `data.error_message` / `error` (Edge) element value in the response body when an error occurs.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
