### PR TITLE
fix: Edge authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.8.0 [unreleased]
 
+### Bug Fixes
+
+1. [#101](https://github.com/InfluxCommunity/influxdb3-python/pull/101): Add support for InfluxDB Edge authentication
+
 ## 0.7.0 [2024-07-11]
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ from influxdb_client_3 import InfluxDBClient3, Point
 ## Initialization
 If you are using InfluxDB Cloud, then you should note that:
 1. You will need to supply your org id, this is not necessary for InfluxDB Dedicated.
-2. Use a bucketname for the database argument.
+2. Use bucket name for the `database` argument.
 
 ```python
 client = InfluxDBClient3(token="your-token",

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -110,7 +110,28 @@ class InfluxDBClient3:
         :type write_client_options: callable
         :param flight_client_options: Function for providing additional arguments for the FlightClient.
         :type flight_client_options: callable
-        :param kwargs: Additional arguments for the InfluxDB Client.
+        :key auth_scheme: token authentication scheme. Set to "Bearer" for Edge.
+        :key bool verify_ssl: Set this to false to skip verifying SSL certificate when calling API from https server.
+        :key str ssl_ca_cert: Set this to customize the certificate file to verify the peer.
+        :key str cert_file: Path to the certificate that will be used for mTLS authentication.
+        :key str cert_key_file: Path to the file contains private key for mTLS certificate.
+        :key str cert_key_password: String or function which returns password for decrypting the mTLS private key.
+        :key ssl.SSLContext ssl_context: Specify a custom Python SSL Context for the TLS/ mTLS handshake.
+                                         Be aware that only delivered certificate/ key files or an SSL Context are
+                                         possible.
+        :key str proxy: Set this to configure the http proxy to be used (ex. http://localhost:3128)
+        :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
+                                authentication.
+        :key int connection_pool_maxsize: Number of connections to save that can be reused by urllib3.
+                                          Defaults to "multiprocessing.cpu_count() * 5".
+        :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests
+                                               except batching writes. As a default there is no one retry strategy.
+        :key bool auth_basic: Set this to true to enable basic authentication when talking to a InfluxDB 1.8.x that
+                              does not use auth-enabled but is protected by a reverse proxy with basic authentication.
+                              (defaults to false, don't set to true when talking to InfluxDB 2)
+        :key str username: ``username`` to authenticate via username and password credentials to the InfluxDB 2.x
+        :key str password: ``password`` to authenticate via username and password credentials to the InfluxDB 2.x
+        :key list[str] profilers: list of enabled Flux profilers
         """
         self._org = org if org is not None else "default"
         self._database = database

--- a/influxdb_client_3/write_client/client/_base.py
+++ b/influxdb_client_3/write_client/client/_base.py
@@ -37,7 +37,6 @@ class _BaseClient(object):
     def __init__(self, url, token, debug=None, timeout=10_000, enable_gzip=False, org: str = None,
                  default_tags: dict = None, http_client_logger: str = None, **kwargs) -> None:
         self.url = url
-        self.token = token
         self.org = org
 
         self.default_tags = default_tags
@@ -70,9 +69,10 @@ class _BaseClient(object):
         self.auth_header_name = None
         self.auth_header_value = None
         # by token
-        if self.token:
+        if token:
+            auth_scheme = kwargs.get('auth_scheme', "Token")
             self.auth_header_name = "Authorization"
-            self.auth_header_value = "Token " + self.token
+            self.auth_header_value = f"{auth_scheme} {token}"
         # by HTTP basic
         auth_basic = kwargs.get('auth_basic', False)
         if auth_basic:

--- a/influxdb_client_3/write_client/client/influxdb_client.py
+++ b/influxdb_client_3/write_client/client/influxdb_client.py
@@ -27,6 +27,7 @@ class InfluxDBClient(_BaseClient):
         :param enable_gzip: Enable Gzip compression for http requests. Currently, only the "Write" and "Query" endpoints
                             supports the Gzip compression.
         :param org: organization name (used as a default in Query, Write and Delete API)
+        :key auth_scheme: token authentication scheme. Set to "Bearer" for Edge.
         :key bool verify_ssl: Set this to false to skip verifying SSL certificate when calling API from https server.
         :key str ssl_ca_cert: Set this to customize the certificate file to verify the peer.
         :key str cert_file: Path to the certificate that will be used for mTLS authentication.

--- a/tests/test_influxdb_client_3.py
+++ b/tests/test_influxdb_client_3.py
@@ -27,6 +27,27 @@ class TestInfluxDBClient3(unittest.TestCase):
         self.assertEqual(self.client._write_api, self.mock_write_api.return_value)
         self.assertEqual(self.client._query_api, self.mock_query_api.return_value)
 
+    # test default token auth_scheme
+    def test_token_auth_scheme_default(self):
+        client = InfluxDBClient3(
+            host="localhost",
+            org="my_org",
+            database="my_db",
+            token="my_token",
+        )
+        self.assertEqual(client._client.auth_header_value, "Token my_token")
+
+    # test explicit token auth_scheme
+    def test_token_auth_scheme_explicit(self):
+        client = InfluxDBClient3(
+            host="localhost",
+            org="my_org",
+            database="my_db",
+            token="my_token",
+            auth_scheme="my_scheme"
+        )
+        self.assertEqual(client._client.auth_header_value, "my_scheme my_token")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Proposed Changes

Adds `auth_scheme` keyword argument to `InfluxDBClient` initialization to allow setting other token authentication scheme other then the default `"Token"` (used for Cloud). For Edge (OSS), users need to set it to `"Bearer"`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)