### PR TITLE
fix: add py.typed to the package definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.9.0 [unreleased]
 
+### Bug Fixes
+1. [#107](https://github.com/InfluxCommunity/influxdb3-python/pull/107): Missing `py.typed` in distribution package
+
 ## 0.8.0 [2024-08-12]
 
 ### Features

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     author_email='contact@influxdata.com',
     url='https://github.com/InfluxCommunity/influxdb3-python',
     packages=find_packages(exclude=['tests', 'tests.*', 'examples', 'examples.*']),
+    package_data={'influxdb_client_3': ['py.typed']},
     extras_require={
         'pandas': ['pandas'],
         'polars': ['polars'],


### PR DESCRIPTION
## Proposed Changes

Fixed adding py.typed into package.

Tested via:

```
mkdir typed
cd typed
python -m venv venv
. venv/bin/activate
python -m pip install git+https://github.com/InfluxCommunity/influxdb3-python.git@typed-definition-setup.py
ls -l venv/lib/python3.11/site-packages/influxdb_client_3/
```


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
