### PR TITLE
fix: #110 - set message 'processor was disposed' to level debug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 1. [#108](https://github.com/InfluxCommunity/influxdb3-python/pull/108): Better expose access to response headers in `InfluxDBError`.  Example `handle_http_error` added.
 
+### Bug Fixes
+
+1. [#111](https://github.com/InfluxCommunity/influxdb3-python/pull/111): Reduce log level of disposal of batch processor to DEBUG
+
 ## 0.8.0 [2024-08-12]
 
 ### Features

--- a/influxdb_client_3/write_client/client/write_api.py
+++ b/influxdb_client_3/write_client/client/write_api.py
@@ -566,7 +566,7 @@ You can use native asynchronous version of the client:
 
     def _on_complete(self):
         self._disposable.dispose()
-        logger.info("the batching processor was disposed")
+        logger.debug("the batching processor was disposed")
 
     def __getstate__(self):
         """Return a dict of attributes that you want to pickle."""


### PR DESCRIPTION
Closes #110

## Proposed Changes

- Change logging level after disposal of batching processor to DEBUG.

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
