### PR TITLE
feat: support script for building and deploying OSS

### DIFF
--- a/scripts/influxdb3-oss-local.sh
+++ b/scripts/influxdb3-oss-local.sh
@@ -80,11 +80,11 @@ then
 fi
 
 printf "Preparing to deploy\n"
-DEPLOY_ARGS="--host-id ${HOST_ID} --object-store ${OBJECT_STORE} --data-dir ${DATA_DIR} --log-filter DEBUG"
+DEPLOY_ARGS="--object-store ${OBJECT_STORE} --data-dir ${DATA_DIR} --log-filter DEBUG"
 
 if [ "${SECURE_DEPLOY}" == "TRUE" ]
 then
-  TOKEN_RESULT=$(${INFLUXDB3_EXE} token create | head -n 2 | sed ':a;N;$!ba;s/\n/#/g')
+  TOKEN_RESULT=$(${INFLUXDB3_EXE} create token | head -n 2 | sed ':a;N;$!ba;s/\n/#/g')
   TOKEN="$(echo "$TOKEN_RESULT" | sed s/\#.*$//g | sed s/^Token:\ //)"
   HASHED_TOKEN="$(echo "$TOKEN_RESULT" | sed s/^.*\#//g | sed s/Hashed\ Token:\ //)"
   DEPLOY_ARGS="${DEPLOY_ARGS} --bearer-token ${HASHED_TOKEN}"
@@ -113,5 +113,5 @@ then
 fi
 
 #${INFLUXDB3_EXE} serve --host-id kk-local --object-store file --data-dir /home/karl/temp/store/db --log-filter DEBUG > influxdb3.log 2>&1 &
-${INFLUXDB3_EXE} serve ${DEPLOY_ARGS} > influxdb3.log 2>&1 &
+${INFLUXDB3_EXE} serve ${DEPLOY_ARGS} --writer-id TEST > influxdb3.log 2>&1 &
 echo $! | tee influxdb3.pid

--- a/scripts/influxdb3-oss-local.sh
+++ b/scripts/influxdb3-oss-local.sh
@@ -23,8 +23,6 @@ then
   fi
 fi
 
-START_DIR=$(pwd)
-
 if ! [ -d "${INFLUXDB3_PRJ_HOME}" ]
 then
   printf "Directory for INFLUXDB3_PRJ_HOME %s not found.\n" "${INFLUXDB3_PRJ_HOME}"

--- a/scripts/influxdb3-oss-local.sh
+++ b/scripts/influxdb3-oss-local.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+DEFAULT_INFLUXDB3_HOME=/usr/local/influxb3
+PROFILE="${INFLUXDB3_PROFILE:-quick-release}"
+
+INFLUXDB3_PRJ_HOME="${INFLUXDB3_PRJ_HOME:-${DEFAULT_INFLUXDB3_HOME}}"
+INFLUXDB3_EXE="${INFLUXDB3_PRJ_HOME}/target/${PROFILE}/influxdb3"
+
+SECURE_DEPLOY="${INFLUXDB3_SECURE_DEPLOY:-TRUE}"
+OBJECT_STORE="${INFLUXDB3_OBJECT_STORE:-file}"
+HOST_ID="${INFLUXDB3_HOST_ID:-client_test}"
+DATA_DIR="${INFLUXDB3_DATA_DIR:-/tmp/influxdb3/data}"
+PROCESS_FILE="$(pwd)/influxdb3.pid"
+
+if [ -f "${PROCESS_FILE}" ]
+then
+  OLD_PROCESS=$(cat ${PROCESS_FILE})
+  if [ -d "/proc/${OLD_PROCESS}" ]
+  then
+    printf "Influxdb3 already running as process %s\n" "${OLD_PROCESS}"
+    printf "EXITING\n"
+    exit 0
+  fi
+fi
+
+START_DIR=$(pwd)
+
+if ! [ -d "${INFLUXDB3_PRJ_HOME}" ]
+then
+  printf "Directory for INFLUXDB3_PRJ_HOME %s not found.\n" "${INFLUXDB3_PRJ_HOME}"
+  printf "Set the environment variable INFLUXDB3_PRJ_HOME to the local project location.\n"
+  printf "ABORTING\n"
+  exit 1
+fi
+
+if ! [ -f "${INFLUXDB3_PRJ_HOME}/Cargo.toml" ]
+then
+  printf "%s exists but is not a Rust/Cargo project.\n" "${INFLUXDB3_PRJ_HOME}"
+  printf "ABORTING\n"
+  exit 1
+fi
+
+if [ -x "${INFLUXDB3_EXE}" ]
+then
+  printf "found %s\n" "$(ls "${INFLUXDB3_EXE}")"
+  printf "build skipped\n"
+  printf "\nto force rebuild run '$ cargo clean' in directory %s, then run this script again\n\n" "${INFLUXDB3_PRJ_HOME}"
+else
+  START_DIR=$(pwd)
+  echo DEBUG START_DIR "${START_DIR}"
+  cd "${INFLUXDB3_PRJ_HOME}" || exit
+  printf "Building Influxdb3 with profile %s\n" "${PROFILE}"
+  printf "Building in %s" "$(pwd)\n"
+  printf "This may take a few minutes\n"
+  cargo build --package="influxdb3" --profile="${PROFILE}" --no-default-features --features="jemalloc_replacing_malloc"
+  BUILD_RESULT=$?
+  # shellcheck disable=SC2164
+  cd "${START_DIR}" || cd -
+  printf "Build end status %s\n" "${BUILD_RESULT}"
+  if [ "${BUILD_RESULT}" != 0 ]
+  then
+    printf "Build failed\n"
+    printf "ABORTING\n"
+    exit ${BUILD_RESULT}
+  fi
+fi
+
+if [ ! -e "${INFLUXDB3_EXE}" ]
+then
+  printf "Failed to locate influxdb3 executable %s\n" "${INFLUXDB3_EXE}"
+  printf "ABORTING\n"
+  exit 1
+fi
+
+if [ ! -x "${INFLUXDB3_EXE}" ]
+then
+  printf "Found influxdb3 file %s\n" "${INFLUXDB3_EXE}"
+  printf "But it is not executable\n"
+  printf "ABORTING"
+  exit 1
+fi
+
+printf "Preparing to deploy\n"
+DEPLOY_ARGS="--host-id ${HOST_ID} --object-store ${OBJECT_STORE} --data-dir ${DATA_DIR} --log-filter DEBUG"
+
+if [ "${SECURE_DEPLOY}" == "TRUE" ]
+then
+  TOKEN_RESULT=$(${INFLUXDB3_EXE} token create | head -n 2 | sed ':a;N;$!ba;s/\n/#/g')
+  TOKEN="$(echo "$TOKEN_RESULT" | sed s/\#.*$//g | sed s/^Token:\ //)"
+  HASHED_TOKEN="$(echo "$TOKEN_RESULT" | sed s/^.*\#//g | sed s/Hashed\ Token:\ //)"
+  DEPLOY_ARGS="${DEPLOY_ARGS} --bearer-token ${HASHED_TOKEN}"
+  printf "User Token will be:\n%s\nStore this somewhere and use it when calling the Influx server\n" "${TOKEN}"
+  echo "export INFLUXDB_TOKEN=${TOKEN}" > influxdb3.token
+fi
+
+if [ ! -d "${DATA_DIR}" ]
+then
+  printf "Making data dir %s\n" "${DATA_DIR}"
+  mkdir -p ${DATA_DIR}
+  RESULT=$?
+  if [ "${RESULT}" != 0 ] && [ "${OBJECT_STORE}" == "file" ]
+  then
+    printf "Failed to create %s when using `file` object store\n" "${DATA_DIR}"
+    printf "ABORTING"
+    exit ${RESULT}
+  fi
+fi
+
+if [ ! -w "${DATA_DIR}" ] && [ "${OBJECT_STORE}" == "file" ]
+then
+  printf "Data dir %s is not writable when using `file` object store\n" "${DATA_DIR}"
+  print "ABORTING"
+  exit 1
+fi
+
+#${INFLUXDB3_EXE} serve --host-id kk-local --object-store file --data-dir /home/karl/temp/store/db --log-filter DEBUG > influxdb3.log 2>&1 &
+${INFLUXDB3_EXE} serve ${DEPLOY_ARGS} > influxdb3.log 2>&1 &
+echo $! | tee influxdb3.pid

--- a/scripts/influxdb3-oss-local.sh
+++ b/scripts/influxdb3-oss-local.sh
@@ -44,6 +44,7 @@ then
   printf "build skipped\n"
   printf "\nto force rebuild run '$ cargo clean' in directory %s, then run this script again\n\n" "${INFLUXDB3_PRJ_HOME}"
 else
+  command -v cargo >/dev/null 2>&1 || { printf "Build requires cargo, but it could not be found.\nABORTING."; exit 1; }
   START_DIR=$(pwd)
   echo DEBUG START_DIR "${START_DIR}"
   cd "${INFLUXDB3_PRJ_HOME}" || exit

--- a/scripts/influxdb3-oss-local.sh
+++ b/scripts/influxdb3-oss-local.sh
@@ -44,7 +44,7 @@ then
   printf "build skipped\n"
   printf "\nto force rebuild run '$ cargo clean' in directory %s, then run this script again\n\n" "${INFLUXDB3_PRJ_HOME}"
 else
-  command -v cargo >/dev/null 2>&1 || { printf "Build requires cargo, but it could not be found.\nABORTING."; exit 1; }
+  command -v cargo >/dev/null 2>&1 || { printf "Build requires cargo, but it could not be found.\nABORTING.\n"; exit 1; }
   START_DIR=$(pwd)
   echo DEBUG START_DIR "${START_DIR}"
   cd "${INFLUXDB3_PRJ_HOME}" || exit


### PR DESCRIPTION
## Proposed Changes

* adds the script `scripts/influxdb3-oss-local.sh` for building and deploying influxdb OSS on the same machine
* purpose is to 
   * standardize build and deployment to simplify testing as OSS is rolled out. 
   * add OSS testing to the build pipeline

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
