### PR TITLE
fix: 118 - query not using proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           name: Checks that the description will render correctly on PyPI.
           command: |
             pip install --upgrade pip
-            pip install twine --user
+            pip install 'twine>=5.1,<6.1' --user
             python setup.py sdist bdist_wheel
             twine check dist/*
   check-docstyle:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.11.0 [unreleased]
 
+### Bug Fixes
+
+1. [#119](https://github.com/InfluxCommunity/influxdb3-python/pull/119): Fix use of `proxy` argument in client and query_api to use in channel solution for GRPC proxy.
+
 ## 0.10.0 [2024-11-27]
 
 ### Bug Fixes

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -121,7 +121,7 @@ class InfluxDBClient3:
                                          possible.
         :key str proxy: Set this to configure the http proxy to be used (ex. http://localhost:3128)
         :key str proxy_headers: A dictionary containing headers that will be sent to the proxy. Could be used for proxy
-                                authentication.
+                                authentication. (Applies to Write API only)
         :key int connection_pool_maxsize: Number of connections to save that can be reused by urllib3.
                                           Defaults to "multiprocessing.cpu_count() * 5".
         :key urllib3.util.retry.Retry retries: Set the default retry strategy that is used for all HTTP requests

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -166,7 +166,8 @@ class InfluxDBClient3:
         else:
             connection_string = f"grpc+tcp://{hostname}:{port}"
         self._query_api = _QueryApi(connection_string=connection_string, token=token,
-                                    flight_client_options=flight_client_options)
+                                    flight_client_options=flight_client_options,
+                                    proxy=kwargs.get("proxy",None))
 
     def write(self, record=None, database=None, **kwargs):
         """

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -167,7 +167,7 @@ class InfluxDBClient3:
             connection_string = f"grpc+tcp://{hostname}:{port}"
         self._query_api = _QueryApi(connection_string=connection_string, token=token,
                                     flight_client_options=flight_client_options,
-                                    proxy=kwargs.get("proxy",None))
+                                    proxy=kwargs.get("proxy", None))
 
     def write(self, record=None, database=None, **kwargs):
         """

--- a/influxdb_client_3/query/query_api.py
+++ b/influxdb_client_3/query/query_api.py
@@ -25,7 +25,8 @@ class QueryApi(object):
     def __init__(self,
                  connection_string,
                  token,
-                 flight_client_options) -> None:
+                 flight_client_options,
+                 proxy = None) -> None:
         """
         Initialize defaults.
 
@@ -35,9 +36,12 @@ class QueryApi(object):
         """
         self._token = token
         self._flight_client_options = flight_client_options or {}
+        self._proxy = proxy
         self._flight_client_options["generic_options"] = [
             ("grpc.secondary_user_agent", USER_AGENT)
         ]
+        if self._proxy:
+            self._flight_client_options["generic_options"].append(("grpc.http_proxy", self._proxy))
         self._flight_client = FlightClient(connection_string, **self._flight_client_options)
 
     def query(self, query: str, language: str, mode: str, database: str, **kwargs):

--- a/influxdb_client_3/query/query_api.py
+++ b/influxdb_client_3/query/query_api.py
@@ -26,7 +26,7 @@ class QueryApi(object):
                  connection_string,
                  token,
                  flight_client_options,
-                 proxy = None) -> None:
+                 proxy=None) -> None:
         """
         Initialize defaults.
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -164,5 +164,3 @@ class TestQuery(unittest.TestCase):
         assert client._query_api._proxy == test_proxy
         assert ('grpc.http_proxy', test_proxy) in\
                client._query_api._flight_client_options.get('generic_options')
-
-

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -150,3 +150,19 @@ class TestQuery(unittest.TestCase):
         )
 
         mock_do_get.assert_called_once_with(expected_ticket, ANY)
+
+    def test_query_proxy_base_client(self):
+        test_proxy = "http://testproxy:5432"
+        client = InfluxDBClient3(
+            host="http://localhost:8443",
+            token="my-token",
+            org="my-org",
+            database="my-database",
+            proxy=test_proxy
+        )
+
+        assert client._query_api._proxy == test_proxy
+        assert ('grpc.http_proxy', test_proxy) in\
+               client._query_api._flight_client_options.get('generic_options')
+
+


### PR DESCRIPTION
Closes #118

## Proposed Changes

* extract proxy argument when creating _query_api and use it as new field for `QueryApi` object
* Use this object to set generic Flight client options

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
