### PR TITLE
feat: asynchronous query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.12.0 [unreleased] 
 
+### Features
+
+1. [123](https://github.com/InfluxCommunity/influxdb3-python/pull/123): Introduces `query_async` method.
+
 ### Bug Fixes
 
 1. [#121](https://github.com/InfluxCommunity/influxdb3-python/pull/121): Fix use of arguments `verify_ssl` and `ssl_ca_cert` in `QueryApi`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Features
 
-1. [123](https://github.com/InfluxCommunity/influxdb3-python/pull/123): Introduces `query_async` method.
+1. [#123](https://github.com/InfluxCommunity/influxdb3-python/pull/123): Introduces `query_async()` method. From this release the client now has a `query_async()` method that takes advantage of asyncio's event loop to run query calls in their own executor.
+
+For example:
+```python
+    table = await client.query_async(query)
+```
 
 ### Bug Fixes
 

--- a/Examples/query_async.py
+++ b/Examples/query_async.py
@@ -78,7 +78,7 @@ async def main():
     write_data(client, measurement)
 
     # run both coroutines simultaneously
-    result = await asyncio.gather(fibio(10, 0.2),query_data(client, measurement))
+    result = await asyncio.gather(fibio(10, 0.2), query_data(client, measurement))
     print(f"fibio sequence = {result[0]}")
     print(f"data set =\n{result[1]}")
 

--- a/Examples/query_async.py
+++ b/Examples/query_async.py
@@ -1,0 +1,87 @@
+import asyncio
+import random
+import time
+
+import pandas
+
+from influxdb_client_3 import InfluxDBClient3
+
+from config import Config
+
+
+async def fibio(iterations, grit=0.5):
+    """
+    example coroutine to run parallel with query_async
+    :param iterations:
+    :param grit:
+    :return:
+    """
+    n0 = 1
+    n1 = 1
+    vals = [n0, n1]
+    for _ in range(iterations):
+        val = n0 + n1
+        n0 = n1
+        n1 = val
+        print(val)
+        vals.append(val)
+        await asyncio.sleep(grit)
+    return vals
+
+
+def write_data(client: InfluxDBClient3, measurement):
+    """
+    Synchronous write - only for preparing data
+    :param client:
+    :param measurement:
+    :return:
+    """
+    ids = ['s3b1', 'dq41', 'sgw22']
+    lp_template = f"{measurement},id=%s speed=%f,alt=%f,bearing=%f %d"
+    data_size = 10
+    data = []
+    interval = 10 * 1_000_000_000
+    ts = time.time_ns() - (interval * data_size)
+    for _ in range(data_size):
+        data.append(lp_template % (ids[random.randint(0, len(ids) - 1)],
+                                   random.random() * 300,
+                                   random.random() * 2000,
+                                   random.random() * 360, ts))
+        ts += interval
+
+    client.write(data)
+
+
+async def query_data(client: InfluxDBClient3, measurement):
+    """
+    Query asynchronously - should not block other coroutines
+    :param client:
+    :param measurement:
+    :return:
+    """
+    query = f"SELECT * FROM \"{measurement}\" WHERE time >= now() - interval '5 minutes' ORDER BY time DESC"
+    print(f"query start:    {pandas.Timestamp(time.time_ns())}")
+    table = await client.query_async(query)
+    print(f"query returned: {pandas.Timestamp(time.time_ns())}")
+    return table.to_pandas()
+
+
+async def main():
+    config = Config()
+    client = InfluxDBClient3(
+        host=config.host,
+        token=config.token,
+        database=config.database,
+        org=config.org
+    )
+    measurement = 'example_uav'
+    write_data(client, measurement)
+
+    # run both coroutines simultaneously
+    result = await asyncio.gather(fibio(10, 0.2),query_data(client, measurement))
+    print(f"fibio sequence = {result[0]}")
+    print(f"data set =\n{result[1]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -279,6 +279,23 @@ class InfluxDBClient3:
             raise e
 
     async def query_async(self, query: str, language: str = "sql", mode: str = "all", database: str = None, **kwargs):
+        """Query data from InfluxDB asynchronously.
+
+        If you want to use query parameters, you can pass them as kwargs:
+
+        >>> await client.query_async("select * from cpu where host=$host", query_parameters={"host": "server01"})
+
+        :param query: The query to execute on the database.
+        :param language: The query language to use. It should be one of "influxql" or "sql". Defaults to "sql".
+        :param mode: The mode to use for the query. It should be one of "all", "pandas", "polars", "chunk",
+                     "reader" or "schema". Defaults to "all".
+        :param database: The database to query from. If not provided, uses the database provided during initialization.
+        :param kwargs: Additional arguments to pass to the ``FlightCallOptions headers``. For example, it can be used to
+                       set up per request headers.
+        :keyword query_parameters: The query parameters to use in the query.
+                                   It should be a ``dictionary`` of key-value pairs.
+        :return: The query result in the specified mode.
+        """
         if mode == "polars" and polars is False:
             raise ImportError("Polars is not installed. Please install it with `pip install polars`.")
 

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -278,6 +278,22 @@ class InfluxDBClient3:
         except InfluxDBError as e:
             raise e
 
+    async def query_async(self, query: str, language: str = "sql", mode: str = "all", database: str = None, **kwargs):
+        if mode == "polars" and polars is False:
+            raise ImportError("Polars is not installed. Please install it with `pip install polars`.")
+
+        if database is None:
+            database = self._database
+
+        try:
+            return await self._query_api.query_async(query=query,
+                                                     language=language,
+                                                     mode=mode,
+                                                     database=database,
+                                                     **kwargs)
+        except InfluxDBError as e:
+            raise e
+
     def close(self):
         """Close the client and clean up resources."""
         self._write_api.close()

--- a/influxdb_client_3/query/query_api.py
+++ b/influxdb_client_3/query/query_api.py
@@ -1,6 +1,5 @@
 """Query data in InfluxDB 3."""
 import asyncio
-import concurrent.futures
 # coding: utf-8
 import json
 
@@ -163,7 +162,6 @@ class QueryApi(object):
                                    It should be a ``dictionary`` of key-value pairs.
         :return: The query result in the specified mode.
         """
-        from influxdb_client_3 import polars as has_polars
         try:
             ticket, _options = self._prepare_query(query, language, database, **kwargs)
 
@@ -178,12 +176,11 @@ class QueryApi(object):
             ticket, options = self._prepare_query(query, language, database, **kwargs)
             loop = asyncio.get_running_loop()
             _flight_reader = await loop.run_in_executor(None,
-                               self._flight_client.do_get, ticket, options)
+                                                        self._flight_client.do_get, ticket, options)
             return await loop.run_in_executor(None, self._translate_stream_reader,
                                               _flight_reader,
                                               mode)
         except Exception as e:
-            print(f"\DEBUG caught exception e {e}")
             raise e
 
     def _translate_stream_reader(self, reader: FlightStreamReader, mode: str):

--- a/influxdb_client_3/query/query_api.py
+++ b/influxdb_client_3/query/query_api.py
@@ -172,6 +172,21 @@ class QueryApi(object):
             raise e
 
     async def query_async(self, query: str, language: str, mode: str, database: str, **kwargs):
+        """Query data from InfluxDB asynchronously.
+
+        Wraps internal FlightClient.doGet call in its own executor, so that the event_loop will not be blocked.
+
+        :param query: The query to execute on the database.
+        :param language: The query language.
+        :param mode: The mode to use for the query.
+             It should be one of "all", "pandas", "polars", "chunk", "reader" or "schema".
+        :param database: The database to query from.
+        :param kwargs: Additional arguments to pass to the ``FlightCallOptions headers``.
+               For example, it can be used to set up per request headers.
+        :keyword query_parameters: The query parameters to use in the query.
+                           It should be a ``dictionary`` of key-value pairs.
+        :return: The query result in the specified mode.
+        """
         try:
             ticket, options = self._prepare_query(query, language, database, **kwargs)
             loop = asyncio.get_running_loop()

--- a/tests/test_influxdb_client_3.py
+++ b/tests/test_influxdb_client_3.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import patch
 
 from influxdb_client_3 import InfluxDBClient3
+from tests.util import asyncio_run
+from tests.util.mocks import ConstantFlightServer, ConstantData
 
 
 class TestInfluxDBClient3(unittest.TestCase):
@@ -47,6 +49,30 @@ class TestInfluxDBClient3(unittest.TestCase):
             auth_scheme="my_scheme"
         )
         self.assertEqual(client._client.auth_header_value, "my_scheme my_token")
+
+    @asyncio_run
+    async def test_query_async(self):
+        with ConstantFlightServer() as server:
+            client = InfluxDBClient3(
+                host=f"http://localhost:{server.port}",
+                org="my_org",
+                database="my_db",
+                token="my_token",
+            )
+
+            query = "SELECT * FROM my_data"
+
+            table = await client.query_async(query=query, language="sql")
+
+            result_list = table.to_pylist()
+
+            cd = ConstantData()
+            for item in cd.to_list():
+                assert item in result_list
+
+            assert {'data': 'database', 'reference': 'my_db', 'value': -1.0} in result_list
+            assert {'data': 'sql_query', 'reference': query, 'value': -1.0} in result_list
+            assert {'data': 'query_type', 'reference': 'sql', 'value': -1.0} in result_list
 
 
 if __name__ == '__main__':

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,8 +1,5 @@
 import asyncio
-import inspect
-import sys
 import time
-import traceback
 import unittest
 import os
 import json
@@ -16,6 +13,7 @@ from pyarrow.flight import (
 from influxdb_client_3 import InfluxDBClient3
 from influxdb_client_3.query.query_api import QueryApiOptionsBuilder, QueryApi
 from influxdb_client_3.version import USER_AGENT
+from tests.util import asyncio_run
 
 from tests.util.mocks import (
     ConstantData,
@@ -27,18 +25,6 @@ from tests.util.mocks import (
     get_req_headers,
     set_req_headers
 )
-
-
-def asyncio_run(async_func):
-    def wrapper(*args, **kwargs):
-        try:
-            return asyncio.run(async_func(*args, **kwargs))
-        except Exception as e:
-            print(traceback.format_exc(), file=sys.stderr)
-            raise e
-
-    wrapper.__signature__ = inspect.signature(async_func)
-    return wrapper
 
 
 def case_insensitive_header_lookup(headers, lkey):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -437,6 +437,10 @@ Aw==
             # fibo started after query_async
             assert events['query_start'] < events['fibo_start'], (f"query_start: {events['query_start']} should start "
                                                                   f"before fibo_start: {events['fibo_start']}")
+            # fibo started before query_async ends - i.e. query_async did not block it
+            assert events['query_result'] > events['fibo_start'], (f"query_result: {events['query_result']} should "
+                                                                   f"occur after fibo_start: {events['fibo_start']}")
+
             # fibo ended before query_async
             assert events['query_result'] > events['fibo_end'], (f"query_result: {events['query_result']} should occur "
                                                                  f"after fibo_end: {events['fibo_end']}")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -240,7 +240,7 @@ Aw==
 
         assert ('opt1', 'opt1 in args') in q_api._flight_client_options['generic_options']
         assert ('optA', 'A in options') in q_api._flight_client_options['generic_options']
-        assert (('grpc.secondary_user_agent', 'influxdb3-python/0.12.0dev0') in
+        assert (('grpc.secondary_user_agent', USER_AGENT) in
                 q_api._flight_client_options['generic_options'])
 
     def test_override_secondary_user_agent_args(self):
@@ -253,7 +253,7 @@ Aw==
         )
 
         assert ('grpc.secondary_user_agent', 'my_custom_user_agent') in q_api._flight_client_options['generic_options']
-        assert not (('grpc.secondary_user_agent', 'influxdb3-python/0.12.0dev0') in
+        assert not (('grpc.secondary_user_agent', USER_AGENT) in
                     q_api._flight_client_options['generic_options'])
 
     def test_secondary_user_agent_in_options(self):
@@ -274,7 +274,7 @@ Aw==
 
         assert ('optA', 'A in options') in q_api._flight_client_options['generic_options']
         assert ('grpc.secondary_user_agent', 'my_custom_user_agent') in q_api._flight_client_options['generic_options']
-        assert (('grpc.secondary_user_agent', 'influxdb3-python/0.12.0dev0') not in
+        assert (('grpc.secondary_user_agent', USER_AGENT) not in
                 q_api._flight_client_options['generic_options'])
 
     def test_prepare_query(self):

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,0 +1,1 @@
+"""Package for tests/util module."""

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -38,23 +38,34 @@ def lp_to_py_object(lp: str):
         result[t_set[0]] = t_set[1]
 
     fields = groups[1].split(',')
+
+    def check_bool(token):
+        if token.lower()[0] == 't':
+            return True
+        return False
+
+    parse_field_val = {
+        'i': lambda s: int(s.replace('i', '')),
+        'u': lambda s: int(s.replace('u', '')),
+        '\"': lambda s: s.replace('"', ''),
+        'e': lambda s: check_bool(s),
+        'E': lambda s: check_bool(s),
+        't': lambda s: check_bool(s),
+        'T': lambda s: check_bool(s),
+        'f': lambda s: check_bool(s),
+        'F': lambda s: check_bool(s),
+        'd': lambda s: float(s)
+    }
+
     for field in fields:
         f_set = field.split('=')
-        lastchar = f_set[1][len(f_set[1]) - 1]
-        match lastchar:
-            case 'i': # integer
-                result[f_set[0]] = int(f_set[1].replace('i',''))
-            case 'u': # unsigned integer
-                result[f_set[0]] = int(f_set[1].replace('u',''))
-            case '"': # string
-                result[f_set[0]] = f_set[1].replace('"',"")
-            case 'e' | 'E' | 't' | 'T' | 'f' | 'F':
-                if f_set[1][0].lower() == 't':
-                    result[f_set[0]] = True
-                else:
-                    result[f_set[0]] = False
-            case _: # assume float
-                result[f_set[0]] = float(f_set[1])
+        last_char = f_set[1][len(f_set[1]) - 1]
+        if last_char in '0123456789':
+            last_char = 'd'
+        if last_char in parse_field_val.keys():
+            result[f_set[0]] = parse_field_val[last_char](f_set[1])
+        else:
+            result[f_set[0]] = None
 
     result['time'] = pandas.Timestamp(int(groups[2]))
     return result

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -8,6 +8,22 @@ import pandas
 
 
 def asyncio_run(async_func):
+    """
+    Fixture for running tests asynchronously
+
+    Example
+
+    .. sourcecode:: python
+
+    @asyncio_run
+    async def test_my_feature(self):
+        asyncio.sleep(1)
+        print("waking...")
+        ...
+
+    :param async_func:
+    :return:
+    """
     def wrapper(*args, **kwargs):
         try:
             return asyncio.run(async_func(*args, **kwargs))

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -1,1 +1,17 @@
 """Package for tests/util module."""
+import asyncio
+import inspect
+import sys
+import traceback
+
+
+def asyncio_run(async_func):
+    def wrapper(*args, **kwargs):
+        try:
+            return asyncio.run(async_func(*args, **kwargs))
+        except Exception as e:
+            print(traceback.format_exc(), file=sys.stderr)
+            raise e
+
+    wrapper.__signature__ = inspect.signature(async_func)
+    return wrapper

--- a/tests/util/__init__.py
+++ b/tests/util/__init__.py
@@ -4,6 +4,8 @@ import inspect
 import sys
 import traceback
 
+import pandas
+
 
 def asyncio_run(async_func):
     def wrapper(*args, **kwargs):
@@ -15,3 +17,44 @@ def asyncio_run(async_func):
 
     wrapper.__signature__ = inspect.signature(async_func)
     return wrapper
+
+
+def lp_to_py_object(lp: str):
+    """
+    Result format matches the format of objects returned in pyarrow.Table.to_pylist.
+
+    For verifying test data returned from queries.
+
+    :param lp: a lineprotocol formatted string
+    :return: a list object
+    """
+    result = {}
+    groups = lp.split(' ')
+
+    tags = groups[0].split(',')
+    tags.remove(tags[0])
+    for tag in tags:
+        t_set = tag.split('=')
+        result[t_set[0]] = t_set[1]
+
+    fields = groups[1].split(',')
+    for field in fields:
+        f_set = field.split('=')
+        lastchar = f_set[1][len(f_set[1]) - 1]
+        match lastchar:
+            case 'i': # integer
+                result[f_set[0]] = int(f_set[1].replace('i',''))
+            case 'u': # unsigned integer
+                result[f_set[0]] = int(f_set[1].replace('u',''))
+            case '"': # string
+                result[f_set[0]] = f_set[1].replace('"',"")
+            case 'e' | 'E' | 't' | 'T' | 'f' | 'F':
+                if f_set[1][0].lower() == 't':
+                    result[f_set[0]] = True
+                else:
+                    result[f_set[0]] = False
+            case _: # assume float
+                result[f_set[0]] = float(f_set[1])
+
+    result['time'] = pandas.Timestamp(int(groups[2]))
+    return result

--- a/tests/util/mocks.py
+++ b/tests/util/mocks.py
@@ -1,0 +1,148 @@
+import json
+import struct
+
+from pyarrow import (
+    array,
+    Table,
+    concat_tables
+)
+
+from pyarrow.flight import (
+    FlightServerBase,
+    RecordBatchStream,
+    ServerMiddlewareFactory,
+    FlightUnauthenticatedError,
+    ServerMiddleware,
+    GeneratorStream,
+    ServerAuthHandler
+)
+
+
+class NoopAuthHandler(ServerAuthHandler):
+    """A no-op auth handler - as seen in pyarrow tests"""
+
+    def authenticate(self, outgoing, incoming):
+        """Do nothing"""
+
+    def is_valid(self, token):
+        """
+        Return an empty string
+        N.B. Returning None causes Type error
+        :param token:
+        :return:
+        """
+        return ""
+
+
+def case_insensitive_header_lookup(headers, lkey):
+    """Lookup the value of a given key in the given headers.
+       The lkey is case-insensitive.
+    """
+    for key in headers:
+        if key.lower() == lkey.lower():
+            return headers.get(key)
+
+
+req_headers = {}
+
+
+def set_req_headers(headers):
+    global req_headers
+    req_headers = headers
+
+
+def get_req_headers():
+    global req_headers
+    return req_headers
+
+
+class ConstantData:
+
+    def __init__(self):
+        self.data = [
+            array(['temp', 'temp', 'temp']),
+            array(['kitchen', 'common', 'foyer']),
+            array([36.9, 25.7, 9.8])
+        ]
+        self.names = ['data', 'reference', 'value']
+
+    def to_tuples(self):
+        response = []
+        for n in range(3):
+            response.append((self.data[0][n].as_py(), self.data[1][n].as_py(), self.data[2][n].as_py()))
+        return response
+
+    def to_list(self):
+        response = []
+        for it in range(len(self.data[0])):
+            item = {}
+            for o in range(len(self.names)):
+                item[self.names[o]] = self.data[o][it].as_py()
+            response.append(item)
+        return response
+
+
+class ConstantFlightServer(FlightServerBase):
+
+    def __init__(self, location=None, options=None, **kwargs):
+        super().__init__(location, **kwargs)
+        self.cd = ConstantData()
+        self.options = options
+
+    # respond with Constant Data plus fields from ticket
+    def do_get(self, context, ticket):
+        result_table = Table.from_arrays(self.cd.data, names=self.cd.names)
+        tkt = json.loads(ticket.ticket.decode('utf-8'))
+        for key in tkt.keys():
+            tkt_data = [
+                array([key]),
+                array([tkt[key]]),
+                array([-1.0])
+            ]
+            result_table = concat_tables([result_table, Table.from_arrays(tkt_data, names=self.cd.names)])
+        return RecordBatchStream(result_table, options=self.options)
+
+
+class HeaderCheckServerMiddlewareFactory(ServerMiddlewareFactory):
+    """Factory to create HeaderCheckServerMiddleware and check header values"""
+    def start_call(self, info, headers):
+        auth_header = case_insensitive_header_lookup(headers, "Authorization")
+        values = auth_header[0].split(' ')
+        if values[0] != 'Bearer':
+            raise FlightUnauthenticatedError("Token required")
+        global req_headers
+        req_headers = headers
+        return HeaderCheckServerMiddleware(values[1])
+
+
+class HeaderCheckServerMiddleware(ServerMiddleware):
+    """
+    Middleware needed to catch request headers via factory
+    N.B. As found in pyarrow tests
+    """
+    def __init__(self, token, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.token = token
+
+    def sending_headers(self):
+        return {'authorization': 'Bearer ' + self.token}
+
+
+class HeaderCheckFlightServer(FlightServerBase):
+    """Mock server handle gRPC do_get calls"""
+    def do_get(self, context, ticket):
+        """Return something to avoid needless errors"""
+        data = [
+            array([b"Vltava", struct.pack('<i', 105), b"FM"])
+        ]
+        table = Table.from_arrays(data, names=['a'])
+        return GeneratorStream(
+            table.schema,
+            self.number_batches(table),
+            options={})
+
+    @staticmethod
+    def number_batches(table):
+        for idx, batch in enumerate(table.to_batches()):
+            buf = struct.pack('<i', idx)
+            yield batch, buf

--- a/tests/util/mocks.py
+++ b/tests/util/mocks.py
@@ -1,5 +1,6 @@
 import json
 import struct
+import time
 
 from pyarrow import (
     array,
@@ -101,6 +102,17 @@ class ConstantFlightServer(FlightServerBase):
             ]
             result_table = concat_tables([result_table, Table.from_arrays(tkt_data, names=self.cd.names)])
         return RecordBatchStream(result_table, options=self.options)
+
+
+class ConstantFlightServerDelayed(ConstantFlightServer):
+
+    def __init__(self, location=None, options=None, delay=0.5, **kwargs):
+        super().__init__(location, **kwargs)
+        self.delay = delay
+
+    def do_get(self, context, ticket):
+        time.sleep(self.delay)
+        return super().do_get(context, ticket)
 
 
 class HeaderCheckServerMiddlewareFactory(ServerMiddlewareFactory):


### PR DESCRIPTION
Closes #

## Proposed Changes

* add `query_async` method to `query_api`
* move query ticket preparation statements to reusable methods in `query_api`
* in `query_async` method wrap call to `FlightClient.doGet` in current event loop retrieved from `asyncio`
* in `query_async` method wrap `FlightStreamReader` translations in same event loop
* unit tests of changes to `query_api`
* in `InfluxDBClient3` expose these changes with new `query_async` method
* unit and integration tests of changes to `InfluxDBClient3`
* refactor flight server mocks and test utility functions to `tests/util`
* in `query_api.__init__()` improve merge of `_flight_client_options` so that some values do not get dropped or overwritten

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
