### PR TITLE
feat: move setup tools to build dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Features
 
-1. [#142](https://github.com/InfluxCommunity/influxdb3-python/pull/142):  Support fast writes without waiting for WAL
+1. [#141](https://github.com/InfluxCommunity/influxdb3-python/pull/141) Move "setuptools" package to build dependency.
+2. [#142](https://github.com/InfluxCommunity/influxdb3-python/pull/142):  Support fast writes without waiting for WAL
    persistence:
    - New write option (`WriteOptions.no_sync`) added: `True` value means faster write but without the confirmation that
      the data was persisted. Default value: `False`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=21.0.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ requires = [
     'reactivex >= 4.0.4',
     'certifi >= 14.05.14',
     'python_dateutil >= 2.5.3',
-    'setuptools >= 21.0.0',
     'urllib3 >= 1.26.0',
     'pyarrow >= 8.0.0'
 ]


### PR DESCRIPTION
Issue link [#695](https://github.com/influxdata/influxdb-client-python/issues/695)

## Proposed Changes

- Move the "setuptools" package to build dependency to accommodate new check from the homeassistant library

_ Before the fix
<img width="1379" alt="Screenshot 2025-06-02 at 08 11 57" src="https://github.com/user-attachments/assets/61aa328f-7d23-4a13-a546-b43d33f954a3" />


_ After the fix: I think the new error message means we have had solved the dependency issue, check out "home-assistant-core/script/hassfest/requirements.py" line 169. The new error message is for the homeassistant team
<img width="1379" alt="Screenshot 2025-06-02 at 08 20 33" src="https://github.com/user-attachments/assets/8da5609e-9ab9-4e15-822f-96f1fb5c00a0" />


_ My steps to reproduce the issue:
 - Checkout [Home assistant core repo](https://github.com/home-assistant/core)
-  Run "source venv/bin/activate"
 - Run "python3 -m script.gen_requirements_all && pip3.13 install -r requirements_all.txt"
 - Run "python3 -m script.hassfest --integration-path "home-assistant-core/homeassistant/components/influxdb" --requirement"

- My steps to fix 
 - Build influxdb-python3 with the latest change -> Upload to PyPi  https://pypi.org/project/sonnh-influxdb3-python/. After that, replace the content of "homeassistant/components/influxdb/manifest.json" like this 
[manifest.json](https://github.com/user-attachments/files/20543851/manifest.json)

 - Run the same steps as when reproducing the issue again
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
