### PR TITLE
chore: remove unused nightly workflow from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,13 +182,9 @@ jobs:
             pip install pydocstyle --user
             pydocstyle --count influxdb_client_3
 
-
 workflows:
   version: 2
   build:
-    when:
-      not:
-        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - check-code-style
       #      - check-docstyle
@@ -204,9 +200,3 @@ workflows:
           name: test-integration
           python-image: << pipeline.parameters.default-python-image >>
           pytest-marker: "integration"
-
-  nightly:
-    when:
-      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-    jobs:
-      - tests-python


### PR DESCRIPTION
Closes #

## Proposed Changes

- Removing the "nightly" setting in the ".circleci/config.yml" file to use the trigger nightly build setting from the CircleCI app.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
