### PR TITLE
feat: add flush for batch writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
    compression for Flight queries:
     - `disable_grpc_compression` parameter in `InfluxDBClient3` constructor
     - `INFLUX_DISABLE_GRPC_COMPRESSION` environment variable support in `from_env()`
+1. [#180](https://github.com/InfluxCommunity/influxdb3-python/pull/180): Add `flush()` method to `InfluxDBClient3`:
+   - Allows flushing the write buffer without closing the client when using batching mode.
+   - Enables applications to ensure data is written before querying, while keeping the client open for further operations.
 
 ### Bug Fixes
 

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -660,6 +660,19 @@ class InfluxDBClient3:
 
         return version
 
+    def flush(self):
+        """
+        Flush any buffered writes to InfluxDB without closing the client.
+
+        This method immediately sends all buffered data points to the server
+        when using batching write mode. After flushing, the client remains
+        open and ready for more writes.
+
+        For synchronous write mode, this is a no-op since data is written
+        immediately.
+        """
+        self._write_api.flush()
+
     def close(self):
         """Close the client and clean up resources."""
         self._write_api.close()

--- a/tests/test_flush.py
+++ b/tests/test_flush.py
@@ -1,0 +1,86 @@
+"""Tests for the flush() method in InfluxDBClient3 and WriteApi."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from influxdb_client_3 import InfluxDBClient3, WriteOptions, write_client_options, WriteType
+
+
+class TestFlushMethod(unittest.TestCase):
+    """Test cases for the flush() method."""
+
+    def test_flush_sends_buffered_data_and_allows_continued_writes(self):
+        """Test that flush() sends pending data and allows continued writes."""
+        write_count = 0
+
+        def success_callback(conf, data):
+            nonlocal write_count
+            write_count += 1
+
+        write_options = WriteOptions(
+            write_type=WriteType.batching,
+            batch_size=1000,
+            flush_interval=60_000,
+            max_close_wait=5_000
+        )
+
+        wc_opts = write_client_options(
+            success_callback=success_callback,
+            write_options=write_options
+        )
+
+        with patch('influxdb_client_3.write_client.client.write_api.WriteApi._post_write') as mock_post:
+            mock_post.return_value = MagicMock()
+
+            client = InfluxDBClient3(
+                host="http://localhost:8086",
+                token="my-token",
+                database="my-db",
+                write_client_options=wc_opts
+            )
+
+            try:
+                # Write data, flush, write more, flush again
+                for i in range(5):
+                    client.write(f"test,tag=value field={i}i")
+                client.flush()
+
+                for i in range(5):
+                    client.write(f"test,tag=value field={i}i")
+                client.flush()
+
+                # Both batches should have been flushed
+                self.assertEqual(2, write_count)
+                self.assertEqual(2, mock_post.call_count)
+
+                # Verify that all 10 data points (5 per batch) were sent
+                for call in mock_post.call_args_list:
+                    args, kwargs = call
+                    body = kwargs.get('body') or args[3]
+                    if isinstance(body, bytes):
+                        body = body.decode('utf-8')
+                    for i in range(5):
+                        self.assertIn(f"test,tag=value field={i}i", body)
+            finally:
+                client.close()
+
+    def test_flush_is_safe_in_synchronous_mode_and_after_close(self):
+        """Test that flush() doesn't crash in sync mode or after close."""
+        # Test synchronous mode
+        sync_opts = write_client_options(write_options=WriteOptions(write_type=WriteType.synchronous))
+        with patch('influxdb_client_3.write_client.client.write_api.WriteApi._post_write'):
+            client = InfluxDBClient3(host="http://localhost:8086", token="t", database="db",
+                                     write_client_options=sync_opts)
+            client.flush()  # Should not raise
+            client.close()
+
+        # Test flush after close in batching mode
+        batch_opts = write_client_options(write_options=WriteOptions(write_type=WriteType.batching))
+        with patch('influxdb_client_3.write_client.client.write_api.WriteApi._post_write'):
+            client = InfluxDBClient3(host="http://localhost:8086", token="t", database="db",
+                                     write_client_options=batch_opts)
+            client.close()
+            client.flush()  # Should not raise
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #162 

## Proposed Changes

- Add `flush()` method to `InfluxDBClient3`
- Allows flushing the write buffer without closing the client when using batching mode.
- Enables applications to ensure data is written before querying, while keeping the client open for further operations.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
