### PR TITLE
feat: add auto-merge configuration for Dependabot PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ workflows:
           matrix:
             parameters:
               exe: [ docker-amd64-image, docker-arm64-image ]
-              python-image: [ << pipeline.parameters.default-python-image >>, "cimg/python:3.9", "cimg/python:3.10", "cimg/python:3.11", "cimg/python:3.12", cimg/python:3.13 ]
+              python-image: [ << pipeline.parameters.default-python-image >>, "cimg/python:3.9", "cimg/python:3.10", "cimg/python:3.11", "cimg/python:3.12", "cimg/python:3.13" ]
       - tests-python:
           requires:
             - tests-python

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Auto-merge Dependabot PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL"
+
+      - name: Enable auto-merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Proposed Changes

This pull request introduces improvements to Dependabot automation and makes a minor fix to the CircleCI workflow configuration. The most significant changes are the addition of an auto-merge workflow for Dependabot PRs and expanding Dependabot update coverage to GitHub Actions.

**Dependabot Automation Enhancements:**

* Added a new GitHub Actions workflow (`.github/workflows/dependabot-auto-merge.yml`) to automatically approve and enable auto-merge for Dependabot pull requests, streamlining dependency updates.
* Updated `.github/dependabot.yml` to include the `github-actions` ecosystem, ensuring that GitHub Actions dependencies are checked and updated by Dependabot.

**CI Configuration Fix:**

* Fixed a syntax issue in the `python-image` matrix parameter in `.circleci/config.yml` by quoting the `cimg/python:3.13` image, ensuring consistent parsing in the workflow.
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
