### PR TITLE
feat: add middleware support for Flight calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.18.0 [unreleased]
 
+### Features
+
+1. [#196](https://github.com/InfluxCommunity/influxdb3-python/pull/196): Support passing middleware functions to the Flight client.
+
 ### Bug Fixes
 
 1. [#194](https://github.com/InfluxCommunity/influxdb3-python/pull/194): Fix `InfluxDBClient3.write_file()` and `InfluxDBClient3.write_dataframe()` fail with batching mode.  

--- a/Examples/query_with_middleware.py
+++ b/Examples/query_with_middleware.py
@@ -1,0 +1,33 @@
+from pyarrow import flight
+
+from config import Config
+from influxdb_client_3 import InfluxDBClient3, flight_client_options
+
+
+# This middleware will add an additional attribute `some-attribute` to the header
+class ModifyHeaderClientMiddleware(flight.ClientMiddleware):
+    def sending_headers(self):
+        return {
+            "some-attribute": "some-value",
+        }
+
+    def received_headers(self, headers):
+        pass
+
+
+class ModifyHeaderClientMiddlewareFactory(flight.ClientMiddlewareFactory):
+    def start_call(self, info):
+        return ModifyHeaderClientMiddleware()
+
+
+config = Config()
+middleware = [ModifyHeaderClientMiddlewareFactory()]
+client = InfluxDBClient3(
+    host=config.host,
+    token=config.token,
+    database=config.database,
+    flight_client_options=flight_client_options(middleware=middleware)
+)
+
+df = client.query(query="select * from cpu11 limit 10", mode="pandas")
+print(len(df))

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -25,7 +25,7 @@ from tests.util.mocks import (
     HeaderCheckServerMiddlewareFactory,
     NoopAuthHandler,
     get_req_headers,
-    set_req_headers, ModifyAuthHeaderClientMiddlewareFactory,
+    set_req_headers, ModifyHeaderClientMiddlewareFactory,
     HeaderCheckServerMiddlewareFactory1
 )
 
@@ -176,7 +176,7 @@ Aw==
         cert_chain = 'mTLS_explicit_chain'
         self.create_cert_file(cert_file)
         test_flight_client_options = {'private_key': private_key, 'cert_chain': cert_chain}
-        middleware = [ModifyAuthHeaderClientMiddlewareFactory()]
+        middleware = [ModifyHeaderClientMiddlewareFactory()]
         options = QueryApiOptionsBuilder()\
             .proxy(proxy_name) \
             .root_certs(cert_file) \
@@ -320,14 +320,13 @@ Aw==
                 auth_handler=NoopAuthHandler(),
                 middleware={"check": HeaderCheckServerMiddlewareFactory1()}) as server:
 
-            middleware = [ModifyAuthHeaderClientMiddlewareFactory()]
+            middleware = [ModifyHeaderClientMiddlewareFactory()]
             client = InfluxDBClient3(
                 host=f'http://localhost:{server.port}',
                 org='test_org',
                 databse='test_db',
                 token='TEST_TOKEN',
                 flight_client_options=flight_client_options(middleware=middleware)
-
             )
 
             df = client.query(query='SELECT * FROM test', mode="pandas")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -335,8 +335,8 @@ Aw==
 
     def test_query_with_missing_middleware(self):
         with HeaderCheckFlightServer(
-            auth_handler=NoopAuthHandler(),
-            middleware={"check": HeaderCheckServerMiddlewareFactory1()}) as server:
+                auth_handler=NoopAuthHandler(),
+                middleware={"check": HeaderCheckServerMiddlewareFactory1()}) as server:
 
             client = InfluxDBClient3(
                 host=f'http://localhost:{server.port}',

--- a/tests/util/mocks.py
+++ b/tests/util/mocks.py
@@ -160,7 +160,7 @@ class HeaderCheckFlightServer(FlightServerBase):
             yield batch, buf
 
 
-class ModifyAuthHeaderClientMiddleware(flight.ClientMiddleware):
+class ModifyHeaderClientMiddleware(flight.ClientMiddleware):
     def sending_headers(self):
         return {
             "header-from-middleware": "some-value",
@@ -170,9 +170,9 @@ class ModifyAuthHeaderClientMiddleware(flight.ClientMiddleware):
         pass
 
 
-class ModifyAuthHeaderClientMiddlewareFactory(flight.ClientMiddlewareFactory):
+class ModifyHeaderClientMiddlewareFactory(flight.ClientMiddlewareFactory):
     def start_call(self, info):
-        return ModifyAuthHeaderClientMiddleware()
+        return ModifyHeaderClientMiddleware()
 
 
 class HeaderCheckServerMiddlewareFactory1(ServerMiddlewareFactory):

--- a/tests/util/mocks.py
+++ b/tests/util/mocks.py
@@ -159,6 +159,7 @@ class HeaderCheckFlightServer(FlightServerBase):
             buf = struct.pack('<i', idx)
             yield batch, buf
 
+
 class ModifyAuthHeaderClientMiddleware(flight.ClientMiddleware):
     def sending_headers(self):
         return {
@@ -168,9 +169,11 @@ class ModifyAuthHeaderClientMiddleware(flight.ClientMiddleware):
     def received_headers(self, headers):
         pass
 
+
 class ModifyAuthHeaderClientMiddlewareFactory(flight.ClientMiddlewareFactory):
     def start_call(self, info):
         return ModifyAuthHeaderClientMiddleware()
+
 
 class HeaderCheckServerMiddlewareFactory1(ServerMiddlewareFactory):
     """Factory to create HeaderCheckServerMiddleware and check header values"""
@@ -181,6 +184,7 @@ class HeaderCheckServerMiddlewareFactory1(ServerMiddlewareFactory):
         global req_headers
         req_headers = headers
         return HeaderCheckServerMiddleware('')
+
 
 class ErrorFlightServer(FlightServerBase):
     def do_get(self, context, ticket):


### PR DESCRIPTION
Closes #

## Proposed Changes

- Allow the users to pass an array of middlewares to our Flight client.
- Add test cases
- Add example query with client middleware

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
