### PR TITLE
fix: v3 error response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 1. [#194](https://github.com/InfluxCommunity/influxdb3-python/pull/194): Fix `InfluxDBClient3.write_file()` and `InfluxDBClient3.write_dataframe()` fail with batching mode.  
+1. [#197](https://github.com/InfluxCommunity/influxdb3-python/pull/197): InfluxDB 3 Core/Enterprise write errors details handling.
 
 ## 0.17.0 [2026-01-08]
 

--- a/influxdb_client_3/exceptions/exceptions.py
+++ b/influxdb_client_3/exceptions/exceptions.py
@@ -74,9 +74,11 @@ class InfluxDBError(InfluxDB3ClientError):
                     message = node.get("message")
                     if message:
                         return f"{code}: {message}" if code else message
-
-                    # InfluxDB v3 write partial error format:
-                    # { "error": "...", "data": [ { "error_message": "...", "line_number": 2, "original_line": "..." }, ... ] }
+                    # InfluxDB v3 write error format:
+                    # {
+                    #   "error": "...",
+                    #   "data": [ { "error_message": "...", "line_number": 2, "original_line": "..." }, ... ]
+                    # }
                     error_text = node.get("error")
                     data = node.get("data")
                     if error_text and isinstance(data, list):

--- a/influxdb_client_3/write_client/rest.py
+++ b/influxdb_client_3/write_client/rest.py
@@ -26,7 +26,6 @@ class ApiException(InfluxDBError):
             self.reason = reason
             self.body = None
             self.headers = None
-        self.status_code = self.status
 
     def __str__(self):
         """Get custom error messages for exception."""

--- a/influxdb_client_3/write_client/rest.py
+++ b/influxdb_client_3/write_client/rest.py
@@ -26,6 +26,7 @@ class ApiException(InfluxDBError):
             self.reason = reason
             self.body = None
             self.headers = None
+        self.status_code = self.status
 
     def __str__(self):
         """Get custom error messages for exception."""

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -149,6 +149,14 @@ class ApiClientTests(unittest.TestCase):
                 "partial write of line protocol occurred:\n"
                 "\tonly error message",
             ),
+            # non-dict item in data list is skipped (line 88)
+            (
+                "non-dict item skipped",
+                '{"error":"partial write of line protocol occurred","data":[null,'
+                '{"error_message":"bad line","line_number":2,"original_line":"bad lp"}]}',
+                "partial write of line protocol occurred:\n"
+                "\tline 2: bad line (bad lp)",
+            ),
             # details empty -> return error_text
             (
                 "no detail fields",

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -124,25 +124,49 @@ class ApiClientTests(unittest.TestCase):
             self._test_api_error(response_body)
         self.assertEqual(response_body, err.exception.message)
 
-    def test_api_error_v3_with_detail_list(self):
-        response_body = (
-            '{"error":"partial write of line protocol occurred","data":['
-            '{"error_message":"invalid column type for column \'v\', expected iox::column_type::field::float, '
-            'got iox::column_type::field::uinteger","line_number":2,"original_line":"**.DBG.remote_***"},'
-            '{"error_message":"invalid column type for column \'v\', expected iox::column_type::field::float, '
-            'got iox::column_type::field::uinteger","line_number":3,"original_line":"***.INF.remote_***"}'
-            ']}'
-        )
-        with self.assertRaises(InfluxDBError) as err:
-            self._test_api_error(response_body)
-        expected = (
-            "partial write of line protocol occurred:\n"
-            "\tline 2: invalid column type for column 'v', expected iox::column_type::field::float, "
-            "got iox::column_type::field::uinteger (**.DBG.remote_***)\n"
-            "\tline 3: invalid column type for column 'v', expected iox::column_type::field::float, "
-            "got iox::column_type::field::uinteger (***.INF.remote_***)"
-        )
-        self.assertEqual(expected, err.exception.message)
+    def test_api_error_v3_with_detail(self):
+        cases = [
+            # all details available
+            (
+                "two-line details",
+                '{"error":"partial write of line protocol occurred","data":['
+                '{"error_message":"invalid column type for column \'v\', expected iox::column_type::field::float, '
+                'got iox::column_type::field::uinteger","line_number":2,"original_line":"**.DBG.remote_***"},'
+                '{"error_message":"invalid column type for column \'v\', expected iox::column_type::field::float, '
+                'got iox::column_type::field::uinteger","line_number":3,"original_line":"***.INF.remote_***"}'
+                ']}',
+                "partial write of line protocol occurred:\n"
+                "\tline 2: invalid column type for column 'v', expected iox::column_type::field::float, "
+                "got iox::column_type::field::uinteger (**.DBG.remote_***)\n"
+                "\tline 3: invalid column type for column 'v', expected iox::column_type::field::float, "
+                "got iox::column_type::field::uinteger (***.INF.remote_***)",
+            ),
+            # error_message only (no line_number/original_line)
+            (
+                "message-only detail",
+                '{"error":"partial write of line protocol occurred","data":['
+                '{"error_message":"only error message"}]}',
+                "partial write of line protocol occurred:\n"
+                "\tonly error message",
+            ),
+            # details empty -> return error_text
+            (
+                "no detail fields",
+                '{"error":"partial write of line protocol occurred","data":[{"line_number":2}]}',
+                "partial write of line protocol occurred",
+            ),
+            # data is not a dict when resolving fallback keys
+            (
+                "data not dict for fallback",
+                '{"error":"data not list","data":"oops"}',
+                "data not list",
+            ),
+        ]
+        for name, response_body, expected in cases:
+            with self.subTest(name):
+                with self.assertRaises(InfluxDBError) as err:
+                    self._test_api_error(response_body)
+                self.assertEqual(expected, err.exception.message)
 
     def test_api_error_headers(self):
         body = '{"error": "test error"}'

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -149,7 +149,7 @@ class ApiClientTests(unittest.TestCase):
                 "partial write of line protocol occurred:\n"
                 "\tonly error message",
             ),
-            # non-dict item in data list is skipped (line 88)
+            # non-dict item in data list is skipped
             (
                 "non-dict item skipped",
                 '{"error":"partial write of line protocol occurred","data":[null,'

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -124,6 +124,26 @@ class ApiClientTests(unittest.TestCase):
             self._test_api_error(response_body)
         self.assertEqual(response_body, err.exception.message)
 
+    def test_api_error_v3_with_detail_list(self):
+        response_body = (
+            '{"error":"partial write of line protocol occurred","data":['
+            '{"error_message":"invalid column type for column \'v\', expected iox::column_type::field::float, '
+            'got iox::column_type::field::uinteger","line_number":2,"original_line":"**.DBG.remote_***"},'
+            '{"error_message":"invalid column type for column \'v\', expected iox::column_type::field::float, '
+            'got iox::column_type::field::uinteger","line_number":3,"original_line":"***.INF.remote_***"}'
+            ']}'
+        )
+        with self.assertRaises(InfluxDBError) as err:
+            self._test_api_error(response_body)
+        expected = (
+            "partial write of line protocol occurred:\n"
+            "\tline 2: invalid column type for column 'v', expected iox::column_type::field::float, "
+            "got iox::column_type::field::uinteger (**.DBG.remote_***)\n"
+            "\tline 3: invalid column type for column 'v', expected iox::column_type::field::float, "
+            "got iox::column_type::field::uinteger (***.INF.remote_***)"
+        )
+        self.assertEqual(expected, err.exception.message)
+
     def test_api_error_headers(self):
         body = '{"error": "test error"}'
         body_dic = json.loads(body)


### PR DESCRIPTION
Closes #

## Proposed Changes

v3 endpoint error can be a structured JSON. eg. write error:

```json
{
  "error": "partial write of line protocol occurred",
  "data": [
    {
      "error_message": "invalid column type for column 'v', expected iox::column_type::field::integer, got iox::column_type::field::float",
      "line_number": 2,
      "original_line": "testa6a3ad v=1 17702"
    }
  ]
}
```

This PR fixes handling of such payload and resulting error message is constructed with all the error detail (and is aligned with other client libs like [influxdb3-go](https://github.com/InfluxCommunity/influxdb3-go/pull/213)):

```
v3 write error message: partial write of line protocol occurred:
	line 2: invalid column type for column 'v', expected iox::column_type::field::integer, got iox::column_type::field::float (testa6a3ad v=1 17702)
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
