### PR TITLE
chore: upgrade Python matrix in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   default-python-image:
     type: string
-    default: "cimg/python:3.8"
+    default: "cimg/python:3.9"
 
 executors:
   docker-amd64-image:
@@ -193,7 +193,7 @@ workflows:
           matrix:
             parameters:
               exe: [ docker-amd64-image, docker-arm64-image ]
-              python-image: [ << pipeline.parameters.default-python-image >>, "cimg/python:3.9", "cimg/python:3.10", "cimg/python:3.11", "cimg/python:3.12", "cimg/python:3.13" ]
+              python-image: [ << pipeline.parameters.default-python-image >>, "cimg/python:3.10", "cimg/python:3.11", "cimg/python:3.12", "cimg/python:3.13", "cimg/python:3.14" ]
       - tests-python:
           requires:
             - tests-python

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install influxdb3-python
 
 Note: This does not include Pandas support. If you would like to use key features such as `to_pandas()`  and `write_file()` you will need to install `pandas` separately.
 
-*Note: Please make sure you are using 3.6 or above. For the best performance use 3.11+*
+*Note: Please make sure you are using 3.9 or above. For the best performance use 3.11+*
 
 # Usage
 One of the easiest ways to get started is to checkout the ["Pokemon Trainer Cookbook"](https://github.com/InfluxCommunity/influxdb3-python/blob/main/Examples/pokemon-trainer/cookbook.ipynb). This scenario takes you through the basics of both the client library and Pyarrow.

--- a/setup.py
+++ b/setup.py
@@ -60,16 +60,16 @@ setup(
         ]
     },
     install_requires=requires,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ]
 )

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -56,7 +56,6 @@ class ApiClientTests(unittest.TestCase):
         return response.HTTPResponse(status=200, version=4, reason="OK", decode_content=False, request_url=url)
 
     def test_default_headers(self):
-        global _package
         conf = Configuration()
         client = ApiClient(conf,
                            header_name="Authorization",
@@ -69,7 +68,6 @@ class ApiClientTests(unittest.TestCase):
     @mock.patch("influxdb_client_3.write_client._sync.rest.RESTClientObject.request",
                 side_effect=mock_rest_request)
     def test_call_api(self, mock_post):
-        global _package
         global _sentHeaders
         _sentHeaders = {}
 

--- a/tests/util/mocks.py
+++ b/tests/util/mocks.py
@@ -53,7 +53,6 @@ def set_req_headers(headers):
 
 
 def get_req_headers():
-    global req_headers
     return req_headers
 
 


### PR DESCRIPTION
3.8 EOL-ed in **2024**! This PR
* upgrades default to 3.9
* adds 3.14 to matrix