### PR TITLE
test: adjust partial writes test to v3.10 behaviour

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x ./codecov
@@ -81,13 +81,14 @@ commands:
       - run:
           name: Collecting coverage reports
           command: |
-            curl -k https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             curl -Os https://uploader.codecov.io/v0.8.0/aarch64/codecov
             curl -Os https://uploader.codecov.io/v0.8.0/aarch64/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/v0.8.0/aarch64/codecov.SHA256SUM.sig
+            curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM
-            sudo chmod +x codecov        
+            sudo chmod +x codecov  
+            ./codecov
 
 jobs:
   tests-python:

--- a/tests/test_influxdb_client_3_integration.py
+++ b/tests/test_influxdb_client_3_integration.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import random
@@ -13,6 +14,7 @@ from urllib3.exceptions import MaxRetryError, TimeoutError as Url3TimeoutError
 from influxdb_client_3 import InfluxDBClient3, write_client_options, WriteOptions, \
     WriteType, InfluxDB3ClientQueryError
 from influxdb_client_3.exceptions import InfluxDBError, InfluxDBPartialWriteError
+from influxdb_client_3.write_client.rest import ApiException
 from tests.util import asyncio_run, lp_to_py_object
 
 
@@ -133,28 +135,37 @@ class TestInfluxDBClient3Integration(unittest.TestCase):
         for accept_partial in [True, False]:
             with self.subTest(accept_partial=accept_partial):
                 with InfluxDBClient3(
-                    host=self.host,
-                    database=self.database,
-                    token=self.token,
-                    write_client_options=write_client_options(write_options=WriteOptions(
-                        write_type=WriteType.synchronous,
-                        use_v2_api=False,
-                        accept_partial=accept_partial
-                    ))
+                        host=self.host,
+                        database=self.database,
+                        token=self.token,
+                        write_client_options=write_client_options(write_options=WriteOptions(
+                            write_type=WriteType.synchronous,
+                            use_v2_api=False,
+                            accept_partial=accept_partial
+                        ))
                 ) as client:
-                    with self.assertRaises(InfluxDBPartialWriteError) as err:
-                        client.write(lp)
+                    if accept_partial:
+                        with self.assertRaises(InfluxDBPartialWriteError) as err:
+                            client.write(lp)
 
-                msg = err.exception.message
-                self.assertTrue(
-                    "partial write of line protocol occurred" in msg or "parsing failed for write_lp endpoint" in msg
-                )
-                self.assertIn((
-                    "invalid column type for column 'temp', expected iox::column_type::field::float, "
-                    "got iox::column_type::field::string"
-                ), msg)
-                self.assertIn("line 2", msg)
-                self.assertIn("home,room=Sunroom", msg)
+                        self.assertEqual(1, len(err.exception.line_errors))
+                        line_error = err.exception.line_errors[0]
+                        self.assertEqual(2, line_error.line_number)
+                        self.assertIn("invalid column type for column 'temp'", line_error.error_message)
+                        self.assertIn("home,room=Sunroom", line_error.original_line)
+                    else:
+                        with self.assertRaises(ApiException) as err:
+                            client.write(lp)
+
+                        self.assertEqual(400, err.exception.status)
+                        self.assertEqual("line protocol parsing error", err.exception.message)
+                        body = json.loads(err.exception.body)
+                        self.assertEqual("line protocol parsing error", body["error"])
+                        self.assertEqual(2, body["data"]["line_number"])
+                        self.assertIn(
+                            "invalid column type for column 'temp'",
+                            body["data"]["error_message"],
+                        )
 
     def test_v2_error(self):
         lp = "\n".join([
@@ -162,23 +173,26 @@ class TestInfluxDBClient3Integration(unittest.TestCase):
             "home,room=Sunroom temp=\"hi\" 1735549200",
         ])
 
-        with InfluxDBClient3(
-            host=self.host,
-            database=self.database,
-            token=self.token,
-            write_client_options=write_client_options(write_options=WriteOptions(
-                write_type=WriteType.synchronous,
-                use_v2_api=True,
-                accept_partial=False
-            ))
-        ) as client:
-            with self.assertRaises(InfluxDBError) as err:
-                client.write(lp)
+        for accept_partial in [True, False]:
+            with self.subTest(accept_partial=accept_partial):
+                with InfluxDBClient3(
+                        host=self.host,
+                        database=self.database,
+                        token=self.token,
+                        write_client_options=write_client_options(write_options=WriteOptions(
+                            write_type=WriteType.synchronous,
+                            use_v2_api=True,
+                            accept_partial=accept_partial
+                        ))
+                ) as client:
+                    with self.assertRaises(ApiException) as err:
+                        client.write(lp)
 
-        self.assertNotIsInstance(err.exception, InfluxDBPartialWriteError)
-        self.assertIsNotNone(err.exception.response)
-        self.assertEqual(400, err.exception.response.status)
-        self.assertTrue(err.exception.message)
+                self.assertEqual(400, err.exception.status)
+                self.assertNotIsInstance(err.exception, InfluxDBPartialWriteError)
+                body = json.loads(err.exception.body)
+                self.assertEqual("invalid", body["code"])
+                self.assertIn("write buffer error", body["message"])
 
     def test_auth_error_token(self):
         self.client = InfluxDBClient3(host=self.host, database=self.database, token='fake token')


### PR DESCRIPTION
Closes #

## Proposed Changes

-  Influxdb3 (3.10 released yesterday) returns different errors, so we need to update our tests to accommodate it.
-  InfluxDB 3.10 write-error behavior

  Endpoint | accept_partial | HTTP | Data written | Expected client behaviour?
  ---------|----------------|---------------|--------------|--------------
  v2       | true           | 400, code="invalid" | None | API Exception/Error
  v2       | false          | 400, code="invalid" | None | API Exception/Error
  v3       | true           | 400, error="partial write of line protocol occurred", data=array | Valid lines written | PartialWrite Exception/Error
  v3       | false          | 400, error="line protocol parsing error", data=object | None | API Exception

- Fix gpg download scripts.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
