### PR TITLE
fix: support ipv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.21.0 [unreleased]
 
+### Bug Fixes
+
+1. [#234](https://github.com/InfluxCommunity/influxdb3-python/pull/234): Add support for connecting to InfluxDB servers using IPv6 addresses.
+    - IPv6 addresses in server URLs must be enclosed in square brackets, for example, http://[2001:db8::1]:8086.
+    - IPv6 zone identifiers are not currently supported.
+
 ### Breaking Changes
 
 1. [#217](https://github.com/InfluxCommunity/influxdb3-python/pull/217): Makes the writing API simpler and more consistent with other v3 clients.

--- a/influxdb_client_3/__init__.py
+++ b/influxdb_client_3/__init__.py
@@ -1,7 +1,6 @@
-import multiprocessing
-
 import importlib.util
 import json
+import multiprocessing
 import os
 import urllib.parse
 from typing import Any, List, Literal, Optional, TYPE_CHECKING
@@ -209,7 +208,8 @@ class InfluxDBClient3:
         """
         Initialize an InfluxDB client.
 
-        :param host: The hostname or IP address of the InfluxDB server.
+        :param host: The hostname or IP address of the InfluxDB server. IPv6 must be wrapped inside square brackets,
+               e.g. http://[2001:db8::1]:8086, and Zone IDs are not supported.
         :type host: str
         :param org: The InfluxDB organization name for operations.
         :type org: str
@@ -306,10 +306,11 @@ class InfluxDBClient3:
 
         # Parse the host input
         parsed_url = urllib.parse.urlparse(host)
-
-        # Determine the protocol (scheme), hostname, and port
-        scheme = parsed_url.scheme if parsed_url.scheme else "https"
         hostname = parsed_url.hostname if parsed_url.hostname else host
+        if "[" in parsed_url.netloc and "]" in parsed_url.netloc:
+            hostname = f"[{hostname}]"
+
+        scheme = parsed_url.scheme if parsed_url.scheme else "https"
         port = parsed_url.port if parsed_url.port else 443
 
         # Construct the clients using the parsed values

--- a/influxdb_client_3/query/query_api.py
+++ b/influxdb_client_3/query/query_api.py
@@ -156,7 +156,8 @@ class QueryApi(object):
         """
         Initialize defaults.
 
-        :param connection_string: Flight/gRPC connection string
+        :param connection_string: Flight/gRPC connection string. IPv6 must be wrapped inside square brackets,
+               e.g. 'grpc+tcp://[2001:db8::1]:8086', and Zone IDs are not supported.
         :param token: access token
         :param flight_client_options: Flight client options
         """

--- a/tests/test_influxdb_client_3.py
+++ b/tests/test_influxdb_client_3.py
@@ -62,6 +62,52 @@ class TestInfluxDBClient3(unittest.TestCase):
         )
         self.assertEqual(client.default_header['Authorization'], "Token my_token")
 
+    def test_parse_addresses(self):
+        tests = [
+            {"url": "http://192.168.0.5/db", "expect": "http://192.168.0.5:443"},
+            {"url": "http://192.168.0.1:80", "expect": "http://192.168.0.1:80"},
+            {"url": "https://[2001:db8::1]", "expect": "https://[2001:db8::1]:443"},
+            {"url": "https://[2001:db8::1]:8086/influx", "expect": "https://[2001:db8::1]:8086"},
+            {"url": "http://[2001:db8::1]:15000?token=my-token", "expect": "http://[2001:db8::1]:15000"},
+            {"url": "http://[2001:db8::1]", "expect": "http://[2001:db8::1]:443"},
+            {"url": "http://[2001:db8:a0b:12f0::1]:80", "expect": "http://[2001:db8:a0b:12f0::1]:80"},
+            {"url": "http://example.com", "expect": "http://example.com:443"},
+            {"url": "http://example.com:3000", "expect": "http://example.com:3000"},
+        ]
+        for test in tests:
+            client = InfluxDBClient3(
+                host=test["url"],
+                org="my_org",
+                database="my_db",
+                token="my_token",
+            )
+            self.assertEqual(client.base_url, test["expect"])
+
+    @patch('influxdb_client_3._QueryApi')
+    def test_ipv6_QueryApi(self, mock_query_api):
+        tests = [
+            {"url": "https://[2001:db8::1]", "expect": "grpc+tls://[2001:db8::1]:443"},
+            {"url": "https://[2001:db8::1]:8086/influx", "expect": "grpc+tls://[2001:db8::1]:8086"},
+            {"url": "http://[2001:db8::1]:15000?token=my-token", "expect": "grpc+tcp://[2001:db8::1]:15000"},
+            {"url": "http://[2001:db8::1]", "expect": "grpc+tcp://[2001:db8::1]:443"},
+            {"url": "http://[2001:db8:a0b:12f0::1]:80", "expect": "grpc+tcp://[2001:db8:a0b:12f0::1]:80"},
+        ]
+        for test in tests:
+            InfluxDBClient3(
+                host=test['url'],
+                org="my_org",
+                database="my_db",
+                token="my_token"
+            )
+            mock_query_api.assert_called_with(
+                connection_string=test['expect'],
+                token="my_token",
+                flight_client_options=None,
+                proxy=None,
+                options=unittest.mock.ANY
+            )
+            mock_query_api.reset_mock()
+
     # test explicit token auth_scheme
     def test_token_auth_scheme_explicit(self):
         client = InfluxDBClient3(


### PR DESCRIPTION
Closes #

## Proposed Changes

- Add tests for IPv6, I only check if our clients can parse the addresses correctly. Real communication tests need to be created inside a machine executor in CircleCI, and It is not worth the efforts, already talked with Jakub about this.
- Arrow Flight Python does not support IPv6 with Zone Ids so we only support IPv6 without zone ids.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
