### PR TITLE
chore: require Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   default-python-image:
     type: string
-    default: "cimg/python:3.9"
+    default: "cimg/python:3.10"
 
 executors:
   docker-amd64-image:
@@ -194,7 +194,7 @@ workflows:
           matrix:
             parameters:
               exe: [ docker-amd64-image, docker-arm64-image ]
-              python-image: [ << pipeline.parameters.default-python-image >>, "cimg/python:3.10", "cimg/python:3.11", "cimg/python:3.12", "cimg/python:3.13", "cimg/python:3.14" ]
+              python-image: [ << pipeline.parameters.default-python-image >>, "cimg/python:3.11", "cimg/python:3.12", "cimg/python:3.13", "cimg/python:3.14" ]
       - tests-python:
           requires:
             - tests-python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.22.0 [unreleased]
 
+### Breaking Changes
+
+1. [#238](https://github.com/InfluxCommunity/influxdb3-python/pull/238): Drop support for Python 3.9. Python 3.10 or newer is now required.
+
 ### Bug Fixes
 
 1. [#237](https://github.com/InfluxCommunity/influxdb3-python/pull/237): Makes the writing API simpler and more consistent with other v3 clients:
@@ -17,7 +21,6 @@
 
 ### Breaking Changes
 
-1. [#238](https://github.com/InfluxCommunity/influxdb3-python/pull/238): Drop support for Python 3.9. Python 3.10 or newer is now required.
 1. [#217](https://github.com/InfluxCommunity/influxdb3-python/pull/217): Makes the writing API simpler and more consistent with other v3 clients.
     - Removes unused `InfluxLoggingHandler` class.
     - `WriteApi` now handles all functions to write to InfluxDB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@
 
 ### Breaking Changes
 
-1. Drop support for Python 3.9. Python 3.10 or newer is now required.
-
+1. [#238](https://github.com/InfluxCommunity/influxdb3-python/pull/238): Drop support for Python 3.9. Python 3.10 or newer is now required.
 1. [#217](https://github.com/InfluxCommunity/influxdb3-python/pull/217): Makes the writing API simpler and more consistent with other v3 clients.
     - Removes unused `InfluxLoggingHandler` class.
     - `WriteApi` now handles all functions to write to InfluxDB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Breaking Changes
 
+1. Drop support for Python 3.9. Python 3.10 or newer is now required.
+
 1. [#217](https://github.com/InfluxCommunity/influxdb3-python/pull/217): Makes the writing API simpler and more consistent with other v3 clients.
     - Removes unused `InfluxLoggingHandler` class.
     - `WriteApi` now handles all functions to write to InfluxDB.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install influxdb3-python
 
 Note: This does not include Pandas support. If you would like to use key features such as `to_pandas()`  and `write_file()`, or to use PyArrow data conversion methods with nanosecond timestamp precision, you will need to install `pandas` separately.
 
-*Note: Please make sure you are using 3.9 or above. For the best performance use 3.11+*
+*Note: Please make sure you are using Python 3.10 or above. For the best performance use 3.11+*
 
 ## CLI (Agent-Friendly Query Tool)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=82.0.1"]
+requires = ["setuptools>=84.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]

--- a/setup.py
+++ b/setup.py
@@ -63,12 +63,11 @@ setup(
     entry_points={
         'console_scripts': ['influx3 = influxdb_client_3.cli:main'],
     },
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
## Summary

- Raise the minimum supported Python version from 3.9 to 3.10.
- Use setuptools 84+, update CircleCI defaults/matrix, and remove the Python 3.9 classifier.
- Document the breaking runtime requirement.

## Verification

- `circleci config validate .circleci/config.yml`
- Built a wheel on Python 3.10 with `Requires-Python: >=3.10`.
- Confirmed Python 3.9 cannot install the project with the new build requirement.