### PR TITLE
fix: partial write error handling

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 ## 0.22.0 [unreleased]
 
+### Breaking Changes
+
+1. [#239](https://github.com/InfluxCommunity/influxdb3-python/pull/239): Exception classes now function mostly like a simple data-carrying object, It stores almost no logics.  
+    - `InfluxDBPartialWriteError` class constructor will now except `message` as an argument.
+    - `InfluxDBPartialWriteError.from_response(cls, response: HTTPResponse):` function was removed.
+
 ### Bug Fixes
 
 1. [#237](https://github.com/InfluxCommunity/influxdb3-python/pull/237): Makes the writing API simpler and more consistent with other v3 clients:
     - Further simplifies the `WriteApi` request path by constructing v2/v3 requests directly through `RestClient`, while preserving existing write behavior.
+1. [#239](https://github.com/InfluxCommunity/influxdb3-python/pull/239):
+    - Only throws `InfluxDBPartialWriteError` when:
+        - Error response status code is `400`.
+        - Error response format `{"error":"...","data":[{"error_message":"...","line_number":2,"original_line": "..."}]}` is returned with `data` must be an array
+        - `accept_partial` is set to `true`.
+        - Write endpoint must be `api/v3/write_lp`.
 
 ## 0.21.0 [2026-08-27]
 

--- a/influxdb_client_3/exceptions/exceptions.py
+++ b/influxdb_client_3/exceptions/exceptions.py
@@ -1,9 +1,8 @@
 """Exceptions utils for InfluxDB."""
 
-import json
 import logging
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from urllib3 import HTTPResponse
 
@@ -42,107 +41,6 @@ class InfluxDB3ClientQueryError(InfluxDB3ClientError):
         self.message = error_message
 
 
-def _is_partial_write_error(error_message) -> bool:
-    if not isinstance(error_message, str) or not error_message:
-        return False
-    normalized = error_message.lower()
-    return (
-        "partial write of line protocol occurred" in normalized or
-        "parsing failed for write_lp endpoint" in normalized
-    )
-
-
-def _parse_partial_write_data_item(item) -> Optional[Tuple[str, int, str]]:
-    if item is None:
-        return None
-    if not isinstance(item, dict):
-        raise ValueError("array item is not an object")
-
-    error_message = item.get("error_message")
-    if not isinstance(error_message, str):
-        raise ValueError("error_message must be string")
-    if not error_message:
-        return None
-
-    line_number_raw = item.get("line_number")
-    if line_number_raw is None:
-        line_number = 0
-    elif isinstance(line_number_raw, int):
-        line_number = line_number_raw
-    else:
-        raise ValueError("line_number must be int")
-
-    original_line_raw = item.get("original_line")
-    if original_line_raw is None:
-        original_line = ""
-    elif isinstance(original_line_raw, str):
-        original_line = original_line_raw
-    else:
-        raise ValueError("original_line must be string")
-
-    return error_message, line_number, original_line
-
-
-def _parse_typed_partial_write_array(data) -> Optional[List[Tuple[str, int, str]]]:
-    if not isinstance(data, list):
-        return None
-    line_errors: List[Tuple[str, int, str]] = []
-    try:
-        for item in data:
-            parsed = _parse_partial_write_data_item(item)
-            if parsed is None:
-                continue
-            line_errors.append(parsed)
-    except ValueError:
-        return None
-    return line_errors if len(line_errors) > 0 else None
-
-
-def _parse_typed_partial_write_object_or_none(data) -> Optional[Tuple[str, int, str]]:
-    try:
-        return _parse_partial_write_data_item(data)
-    except ValueError:
-        return None
-
-
-def _format_partial_write_details(line_errors: List[Tuple[str, int, str]]) -> List[str]:
-    details: List[str] = []
-    for error_message, line_number, original_line in line_errors:
-        if line_number != 0:
-            if original_line != "":
-                details.append(f"\tline {line_number}: {error_message} ({original_line})")
-            else:
-                details.append(f"\tline {line_number}: {error_message}")
-        elif error_message:
-            details.append(f"\t{error_message}")
-    return details
-
-
-def _parse_partial_write_line_error_info(data) -> Tuple[List[Tuple[str, int, str]], List[str]]:
-    if data is None:
-        return [], []
-
-    typed_array = _parse_typed_partial_write_array(data)
-    if typed_array is not None:
-        return typed_array, _format_partial_write_details(typed_array)
-
-    if isinstance(data, list):
-        details: List[str] = []
-        for item in data:
-            if item is None:
-                continue
-            raw = json.dumps(item, separators=(',', ':'))
-            if raw and raw.lower() != "null":
-                details.append(raw)
-        return [], details
-
-    typed_single = _parse_typed_partial_write_object_or_none(data)
-    if typed_single is not None:
-        return [typed_single], _format_partial_write_details([typed_single])
-
-    return [], []
-
-
 # This error is for all write operations
 class InfluxDBError(InfluxDB3ClientError):
     """Raised when a server error occurs."""
@@ -151,63 +49,13 @@ class InfluxDBError(InfluxDB3ClientError):
         """Initialize the InfluxDBError handler."""
         if response is not None:
             self.response = response
-            self.message = self._get_message(response)
+            self.message = message
             self.retry_after = response.getheader('Retry-After')
         else:
             self.response = None
             self.message = message or 'no response'
             self.retry_after = None
         super().__init__(self.message)
-
-    def _get_message(self, response):
-        if response.data:
-            def get(d, key):
-                if not key or d is None:
-                    return d
-                if not isinstance(d, dict):
-                    return None
-                return get(d.get(key[0]), key[1:])
-            try:
-                node = json.loads(response.data)
-                if isinstance(node, dict):
-                    # InfluxDB v3 error format: { "code": "...", "message": "..." }
-                    code = node.get("code")
-                    message = node.get("message")
-                    if message:
-                        return f"{code}: {message}" if code else message
-                    # InfluxDB v3 write error format:
-                    # {
-                    #   "error": "...",
-                    #   "data": [ { "error_message": "...", "line_number": 2, "original_line": "..." }, ... ]
-                    # }
-                    error_text = node.get("error")
-                    if error_text and _is_partial_write_error(error_text):
-                        _, details = _parse_partial_write_line_error_info(node.get("data"))
-                        if details:
-                            return error_text + ":\n" + "\n".join(
-                                detail if detail.startswith("\t") else f"\t{detail}"
-                                for detail in details
-                            )
-                        return error_text
-                    if error_text:
-                        return error_text
-                for key in [['message'], ['data', 'error_message'], ['error']]:
-                    value = get(node, key)
-                    if value is not None:
-                        return value
-                return response.data
-            except Exception as e:
-                logging.debug(f"Cannot parse error response to JSON: {response.data}, {e}")
-                return response.data
-
-        # Header
-        for header_key in ["X-Platform-Error-Code", "X-Influx-Error", "X-InfluxDb-Error"]:
-            header_value = response.getheader(header_key)
-            if header_value is not None:
-                return header_value
-
-        # Http Status
-        return response.reason
 
     def getheaders(self):
         """Helper method to make response headers more accessible."""
@@ -216,40 +64,14 @@ class InfluxDBError(InfluxDB3ClientError):
 
 @dataclass(frozen=True)
 class InfluxDBPartialWriteLineError:
-    line_number: int
-    error_message: str
-    original_line: str
+    line_number: Optional[int]
+    error_message: Optional[str]
+    original_line: Optional[str]
 
 
 class InfluxDBPartialWriteError(InfluxDBError):
     """Structured partial-write error with per-line failures."""
 
-    def __init__(self, response: HTTPResponse, line_errors: List[InfluxDBPartialWriteLineError]):
-        super().__init__(response=response)
+    def __init__(self, response: HTTPResponse, message: str, line_errors: List[InfluxDBPartialWriteLineError]):
+        super().__init__(response=response, message=message)
         self.line_errors = line_errors
-
-    @classmethod
-    def from_response(cls, response: HTTPResponse):
-        if response is None or not response.data:
-            return None
-        try:
-            node = json.loads(response.data)
-        except Exception:
-            return None
-        if not isinstance(node, dict):
-            return None
-        error_text = node.get("error")
-        if not _is_partial_write_error(error_text):
-            return None
-        parsed_line_errors, _ = _parse_partial_write_line_error_info(node.get("data"))
-        if not parsed_line_errors:
-            return None
-        line_errors = [
-            InfluxDBPartialWriteLineError(
-                line_number=line_number,
-                error_message=error_message,
-                original_line=original_line,
-            )
-            for error_message, line_number, original_line in parsed_line_errors
-        ]
-        return cls(response=response, line_errors=line_errors)

--- a/influxdb_client_3/write_client/_sync/rest_client.py
+++ b/influxdb_client_3/write_client/_sync/rest_client.py
@@ -175,7 +175,10 @@ class RestClient(object):
             raise ApiException(status=0, reason=msg)
 
         r = RESTResponse(r)
-        r.data = r.data.decode('utf8')
+        if r.data is not None and r.data != "":
+            r.data = r.data.decode('utf8')
+        else:
+            r.data = None
 
         if self.debug:
             RestClient.log_response(r.status)

--- a/influxdb_client_3/write_client/client/write/retry.py
+++ b/influxdb_client_3/write_client/client/write/retry.py
@@ -10,6 +10,7 @@ from urllib3 import Retry
 from urllib3.exceptions import MaxRetryError, ResponseError
 
 from influxdb_client_3.exceptions import InfluxDBError
+from influxdb_client_3.write_client.write_exceptions import ApiException, translate_write_exception
 
 logger = logging.getLogger('influxdb_client.client.write.retry')
 
@@ -124,7 +125,8 @@ class WritesRetry(Retry):
         new_retry = super().increment(method, url, response, error, _pool, _stacktrace)
 
         if response is not None:
-            parsed_error = InfluxDBError(response=response)
+            api_exception = translate_write_exception(exc=ApiException(http_resp=response))
+            parsed_error = InfluxDBError(response=response, message=api_exception.message)
         elif error is not None:
             parsed_error = error
         else:

--- a/influxdb_client_3/write_client/client/write_api.py
+++ b/influxdb_client_3/write_client/client/write_api.py
@@ -11,7 +11,6 @@ import os
 import warnings
 from collections import defaultdict
 from enum import Enum
-from http import HTTPStatus
 from multiprocessing.pool import ThreadPool
 from random import random
 from time import sleep
@@ -23,21 +22,19 @@ from reactivex import operators as ops, Observable
 from reactivex.scheduler import ThreadPoolScheduler
 from reactivex.subject import Subject
 
-from influxdb_client_3.exceptions import InfluxDBPartialWriteError
 from influxdb_client_3.write_client._sync.rest_client import RestClient
-# from influxdb_client_3.write_client.client._base import _HAS_DATACLASS
 from influxdb_client_3.write_client.client.write.dataframe_serializer import DataframeSerializer
 from influxdb_client_3.write_client.client.write.point import Point, DEFAULT_WRITE_PRECISION, sanitize_tag_order
 from influxdb_client_3.write_client.client.write.retry import WritesRetry
 from influxdb_client_3.write_client.domain import WritePrecision
 from influxdb_client_3.write_client.domain.write_precision_converter import WritePrecisionConverter
-from influxdb_client_3.write_client.write_exceptions import _UTF_8_encoding, ApiException
 from influxdb_client_3.write_client.write_defaults import (
     DEFAULT_WRITE_ACCEPT_PARTIAL as _DEFAULT_WRITE_ACCEPT_PARTIAL,
     DEFAULT_WRITE_NO_SYNC as _DEFAULT_WRITE_NO_SYNC,
     DEFAULT_WRITE_TIMEOUT as _DEFAULT_WRITE_TIMEOUT,
     DEFAULT_WRITE_USE_V2_API as _DEFAULT_WRITE_USE_V2_API,
 )
+from influxdb_client_3.write_client.write_exceptions import _UTF_8_encoding, ApiException, translate_write_exception
 
 # Deprecated compatibility aliases.
 # New code should import these defaults from `influxdb_client_3.write_client.write_defaults`.
@@ -487,7 +484,7 @@ class WriteApi:
                 http_kwargs.get('urlopen_kw', None),
             )
         except ApiException as e:
-            raise self._translate_write_exception(e, use_v2_api)
+            raise translate_write_exception(e, use_v2_api, accept_partial=accept_partial)
 
     def flush(self):
         """
@@ -682,7 +679,7 @@ class WriteApi:
                     try:
                         return original_get(timeout=timeout)
                     except ApiException as e:
-                        raise self._translate_write_exception(e, use_v2_api)
+                        raise translate_write_exception(e, use_v2_api, accept_partial)
 
                 result.get = translated_get
                 return result
@@ -693,7 +690,7 @@ class WriteApi:
                 http_kwargs.get('_request_timeout'),
                 http_kwargs.get('urlopen_kw', None))
         except ApiException as e:
-            raise self._translate_write_exception(e, use_v2_api)
+            raise translate_write_exception(e, use_v2_api, accept_partial)
 
     def _build_write_request(self, org, bucket, precision, no_sync, accept_partial, use_v2_api, **kwargs):
         if org is None:
@@ -782,26 +779,6 @@ class WriteApi:
         self.last_response = response_data
 
         return response_data
-
-    def _translate_write_exception(self, exc, use_v2_api):
-        if use_v2_api and exc.status == HTTPStatus.METHOD_NOT_ALLOWED:
-            message = ("Server doesn't support the V2 API endpoint (/api/v2/write). "
-                       "Set use_v2_api=False to use the V3 API endpoint.")
-            ex = ApiException(status=0, reason=message)
-            ex.message = message
-            ex.args = (message,)
-            return ex
-        if not use_v2_api and exc.status == HTTPStatus.METHOD_NOT_ALLOWED:
-            message = ("Server doesn't support the V3 API endpoint (/api/v3/write_lp). "
-                       "Set use_v2_api=True to use the V2 API endpoint.")
-            ex = ApiException(status=0, reason=message)
-            ex.message = message
-            ex.args = (message,)
-            return ex
-        partial = InfluxDBPartialWriteError.from_response(exc.response)
-        if partial is not None:
-            return partial
-        return exc
 
     def _should_gzip(self, payload: str, enable_gzip: bool = False, gzip_threshold: int = None) -> bool:
         """

--- a/influxdb_client_3/write_client/write_exceptions.py
+++ b/influxdb_client_3/write_client/write_exceptions.py
@@ -2,9 +2,17 @@
 
 from __future__ import absolute_import
 
-from influxdb_client_3.exceptions import InfluxDBError
+import json
+import logging
+from http import HTTPStatus
+from json import JSONDecodeError
+from typing import Union, Optional, Any, Tuple, List
+
+from influxdb_client_3.exceptions import InfluxDBError, InfluxDBPartialWriteError, InfluxDBPartialWriteLineError
 
 _UTF_8_encoding = 'utf-8'
+
+logger = logging.getLogger('influxdb_client_3.write_client.write_exceptions')
 
 
 class ApiException(InfluxDBError):
@@ -35,3 +43,183 @@ class ApiException(InfluxDBError):
             error_message += "HTTP response body: {0}\n".format(self.body)
 
         return error_message
+
+
+def translate_write_exception(
+        exc: ApiException,
+        use_v2_api=False,
+        accept_partial=False,
+) -> Union[ApiException, InfluxDBPartialWriteError]:
+    if exc.status == HTTPStatus.METHOD_NOT_ALLOWED:
+        return create_unsupported_endpoint_exception(use_v2_api)
+
+    if exc.body is None and exc.status == 0:
+        return exc
+
+    root = parse_json(exc.body)
+    if (root is None or
+            root == "" or
+            isinstance(root, dict) is False or
+            (isinstance(root, dict) and (not root.get("error") and not root.get("message")))):
+        message = extract_fallback_reason(exc.response)
+        exc.message = message
+        return exc
+
+    if is_partial_write_error(exc.status, use_v2_api, accept_partial, root):
+        # InfluxDB 3 Core/Enterprise partial write error format:
+        # {"error":"...","data":[{"error_message":"...","line_number":2,"original_line": "..."}]}
+        return handle_partial_write_error(exc.response, root)
+
+    exc.message = get_message(root, exc.response)
+    return exc
+
+
+def get_message(root, response):
+    if root:
+        try:
+            if isinstance(root, dict):
+                # InfluxDB v3 error format: { "code": "...", "message": "..." }
+                message = root.get("message")
+                if message:
+                    code = root.get("code")
+                    return f"{code}: {message}" if code else message
+
+                error_text = root.get("error")
+                data = root.get("data")
+                if error_text and isinstance(data, dict):
+                    # Core/Enterprise object format:
+                    # {"error":"...","data":{"error_message":"..."}}
+                    return format_object_data_error(root.get("data"), error_text)
+                return error_text
+        except Exception as e:
+            logger.debug("Cannot parse error response to JSON: %s, %s", response.data, e)
+            return response.data
+    return None
+
+
+def parse_json(json_str: Optional[Union[str, bytes]]) -> Optional[Any]:
+    if not json_str:
+        return None
+    try:
+        return json.loads(json_str)
+    except (JSONDecodeError, TypeError, ValueError) as e:
+        logger.debug("Can't parse msg from response body %s: %s", json_str, e)
+        return None
+
+
+def create_unsupported_endpoint_exception(use_v2_api: bool) -> ApiException:
+    if use_v2_api:
+        message = ("Server doesn't support the V2 API endpoint (/api/v2/write). "
+                   "Set use_v2_api=False to use the V3 API endpoint.")
+    else:
+        message = ("Server doesn't support the V3 API endpoint (/api/v3/write_lp). "
+                   "Set use_v2_api=True to use the V2 API endpoint.")
+    ex = ApiException(status=0, reason=message)
+    ex.message = message
+    ex.args = (message,)
+    return ex
+
+
+def is_partial_write_error_data_shape(root):
+    return (isinstance(root, dict) and
+            root.get("error") is not None and
+            (isinstance(root.get('data'), list) and
+             len(root.get('data')) > 0))
+
+
+def is_partial_write_error(status_code: int, use_v2_api: bool, accept_partial: bool, root: dict) -> bool:
+    return (status_code == HTTPStatus.BAD_REQUEST and
+            accept_partial is True and
+            use_v2_api is False and
+            is_partial_write_error_data_shape(root)
+            )
+
+
+def format_object_data_error(data_node: dict, error: str) -> str:
+    line_number = data_node.get("line_number")
+    error_message = data_node.get("error_message")
+    original_line = data_node.get("original_line")
+
+    if error_message and isinstance(line_number, int) is False:
+        return f"{error}:\n\t{error_message}"
+    elif error_message and isinstance(line_number, int) and not original_line:
+        return f"{error}:\n\tline {line_number}: {error_message}"
+    elif error_message and original_line:
+        return f"{error}:\n\tline {line_number}: {error_message} ({original_line})"
+
+    return error
+
+
+def handle_partial_write_error(response, root: dict) -> InfluxDBPartialWriteError:
+    reason = root.get("error") or ""
+    all_typed, line_errors = parse_partial_write_line_errors(root.get("data"))
+    line_error_details = format_partial_write_details(root, all_typed, line_errors)
+    if line_error_details:
+        details_str = "".join(f"\n\t{detail}" for detail in line_error_details)
+        reason = f"{reason}:{details_str}"
+    return InfluxDBPartialWriteError(response, reason, line_errors)
+
+
+def format_line_error(line_number: Optional[int], error_message: Optional[str], original_line: Optional[str]) -> str:
+    if line_number is not None and original_line is not None:
+        return f"line {line_number}: {error_message} ({original_line})"
+    if line_number is not None:
+        return f"line {line_number}: {error_message}"
+    return f"{error_message}"
+
+
+def parse_partial_write_line_error(item: dict) -> tuple[bool, Optional[InfluxDBPartialWriteLineError]]:
+    ok = True
+    if not isinstance(item, dict):
+        return False, None
+
+    line_number = item.get("line_number")
+    if line_number is not None and (not isinstance(line_number, int) or isinstance(line_number, bool)):
+        ok = False
+
+    error_message = item.get("error_message")
+    if not error_message:
+        ok = False
+
+    return ok, InfluxDBPartialWriteLineError(line_number, error_message, item.get("original_line"))
+
+
+def parse_partial_write_line_errors(data: Any) -> Tuple[bool, List[InfluxDBPartialWriteLineError]]:
+    all_typed = True
+    line_errors = []
+    for item in data:
+        ok, line_error = parse_partial_write_line_error(item)
+        if not ok:
+            all_typed = False
+            continue
+        line_errors.append(line_error)
+
+    return all_typed, line_errors
+
+
+def extract_fallback_reason(response) -> str:
+    # Fallback to header
+    for header_key in ["X-Platform-Error-Code", "X-Influx-Error", "X-InfluxDb-Error"]:
+        header_value = response.getheader(header_key)
+        if header_value is not None:
+            return header_value
+
+    # Fallback to raw body
+    if response.data is not None and response.data != "":
+        return response.data
+
+    # Fallback to http Status
+    return response.reason
+
+
+def format_partial_write_details(
+        root: dict, all_typed: bool, line_errors: List[InfluxDBPartialWriteLineError]
+) -> List[str]:
+    if all_typed:
+        return [format_line_error(err.line_number, err.error_message, err.original_line) for err in line_errors]
+
+    return [
+        json.dumps(raw, separators=(',', ':'))
+        for raw in (root.get('data') or [])
+        if raw is not None and raw != "null"
+    ]

--- a/tests/test_influxdb_client_3_integration.py
+++ b/tests/test_influxdb_client_3_integration.py
@@ -199,7 +199,7 @@ class TestInfluxDBClient3Integration(unittest.TestCase):
                             client.write(lp)
 
                         self.assertEqual(400, err.exception.status)
-                        self.assertEqual("line protocol parsing error", err.exception.message)
+                        self.assertIn("line protocol parsing error", err.exception.message)
                         body = json.loads(err.exception.body)
                         self.assertEqual("line protocol parsing error", body["error"])
                         self.assertEqual(2, body["data"]["line_number"])

--- a/tests/test_write_api.py
+++ b/tests/test_write_api.py
@@ -1,20 +1,291 @@
 import asyncio
+import http
 import json
 import unittest
 import uuid
+from dataclasses import dataclass, field
+from typing import Optional, List
 from unittest import mock
 
 import pytest
 from urllib3 import response
-from urllib3.exceptions import ConnectTimeoutError
+from urllib3.exceptions import ConnectTimeoutError, ProtocolError, SSLError
 
 from influxdb_client_3 import InfluxDBClient3, InfluxDBError
-from influxdb_client_3.exceptions import InfluxDBPartialWriteError
+from influxdb_client_3.exceptions import InfluxDBPartialWriteError, InfluxDBPartialWriteLineError
 from influxdb_client_3.version import VERSION
-from influxdb_client_3.write_client.write_exceptions import ApiException
+from influxdb_client_3.write_client.client.write.retry import WritesRetry
+from influxdb_client_3.write_client.write_exceptions import (
+    ApiException,
+    translate_write_exception,
+    is_partial_write_error,
+)
 
 _package = "influxdb3-python"
 _sentHeaders = {}
+
+
+@dataclass
+class TestCase:
+    __test__ = False
+    name: str
+    status_code: int
+    response_body: str
+    content_type: Optional[str] = None
+    use_v2_api: bool = False
+    accept_partial: bool = False
+    expected_msg: str = ""
+    expect_partial: bool = False
+    expected_lines: List[InfluxDBPartialWriteLineError] = field(default_factory=list)
+
+    def __str__(self):
+        return self.name
+
+
+POINTS = (
+    "home,room=Sunroom temp=96 1735545600\n"
+    'home,room=Sunroom temp="hi" 1735545610\n'
+    "home,room=Sunroom temp=88i 1735545620"
+)
+REJECTED_LINE = 'home,room=Sunroom temp="hi" 1735545610'
+REJECTED_LINE_JSON = 'home,room=Sunroom temp=\\"hi\\" 1735545610'
+LINE_ERROR = (
+    "invalid column type for column 'temp', expected "
+    "iox::column_type::field::float, got iox::column_type::field::string"
+)
+
+TEST_CASES = [
+    TestCase(
+        name="V3 accept partial with renamed error and non-empty array",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=(
+            f'{{"error":"write completed with rejected rows","data":['
+            f'{{"error_message":"{LINE_ERROR}","line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}'
+            f"]}}"
+        ),
+        accept_partial=True,
+        expected_msg=f"write completed with rejected rows:\n\tline 2: {LINE_ERROR} ({REJECTED_LINE})",
+        expect_partial=True,
+        expected_lines=[
+            InfluxDBPartialWriteLineError(
+                error_message=LINE_ERROR,
+                line_number=2,
+                original_line=REJECTED_LINE,
+            )
+        ],
+    ),
+    TestCase(
+        name="V3 accept partial without content type",
+        status_code=http.client.BAD_REQUEST,
+        content_type=None,
+        response_body=(
+            f'{{"error":"write completed with rejected rows","data":['
+            f'{{"error_message":"{LINE_ERROR}","line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}'
+            f"]}}"
+        ),
+        accept_partial=True,
+        expected_msg=f"write completed with rejected rows:\n\tline 2: {LINE_ERROR} ({REJECTED_LINE})",
+        expect_partial=True,
+        expected_lines=[
+            InfluxDBPartialWriteLineError(
+                error_message=LINE_ERROR,
+                line_number=2,
+                original_line=REJECTED_LINE,
+            )
+        ],
+    ),
+    TestCase(
+        name="V3 accept partial with malformed non-empty array",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=(
+            f'{{"error":"write completed with rejected rows","data":['
+            f'{{"line_number":"invalid","original_line":"{REJECTED_LINE_JSON}"}}'
+            f"]}}"
+        ),
+        accept_partial=True,
+        expected_msg=f'write completed with rejected rows:\n\t{{"line_number":"invalid","original_line":'
+                     f'"{REJECTED_LINE_JSON}"}}',
+        expect_partial=True,
+        expected_lines=[],
+    ),
+    TestCase(
+        name="V3 accept partial with mixed primitive and typed entries",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=(
+            f'{{"error":"write completed with rejected rows","data":['
+            f'1,{{"error_message":"{LINE_ERROR}","line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}'
+            f"]}}"
+        ),
+        accept_partial=True,
+        expected_msg=(
+            f"write completed with rejected rows:\n\t1\n\t"
+            f'{{"error_message":"{LINE_ERROR}","line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}'
+        ),
+        expect_partial=True,
+        expected_lines=[
+            InfluxDBPartialWriteLineError(
+                error_message=LINE_ERROR,
+                line_number=2,
+                original_line=REJECTED_LINE,
+            )
+        ],
+    ),
+    TestCase(
+        name="V3 accept partial with string entries",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=f'{{"error":"write completed with rejected rows","data":["{REJECTED_LINE_JSON}"]}}',
+        accept_partial=True,
+        expected_msg=f'write completed with rejected rows:\n\t"{REJECTED_LINE_JSON}"',
+        expect_partial=True,
+        expected_lines=[],
+    ),
+    TestCase(
+        name="V3 accept partial with error message only",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=f'{{"error":"write completed with rejected rows",'
+                      f'"data":[{{"error_message":"{LINE_ERROR}"}}]}}',
+        accept_partial=True,
+        expected_msg=f"write completed with rejected rows:\n\t{LINE_ERROR}",
+        expect_partial=True,
+        expected_lines=[
+            InfluxDBPartialWriteLineError(
+                error_message=LINE_ERROR,
+                line_number=None,
+                original_line=None,
+            )
+        ],
+    ),
+    TestCase(
+        name="V3 accept partial with line number but no original line",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=f'{{"error":"write completed with rejected rows","data":[{{"error_message":"{LINE_ERROR}",'
+                      f'"line_number":2}}]}}',
+        accept_partial=True,
+        expected_msg=f"write completed with rejected rows:\n\tline 2: {LINE_ERROR}",
+        expect_partial=True,
+        expected_lines=[
+            InfluxDBPartialWriteLineError(
+                error_message=LINE_ERROR,
+                line_number=2,
+                original_line=None,
+            )
+        ],
+    ),
+    TestCase(
+        name="V3 accept partial with entry missing error message",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=f'{{"error":"write completed with rejected rows",'
+                      f'"data":[{{"line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}]}}',
+        accept_partial=True,
+        expected_msg=f'write completed with rejected rows:\n\t{{"line_number":2,'
+                     f'"original_line":"{REJECTED_LINE_JSON}"}}',
+        expect_partial=True,
+        expected_lines=[],
+    ),
+    TestCase(
+        name="V3 accept partial with empty array",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body='{"error":"write failed","data":[]}',
+        accept_partial=True,
+        expected_msg="write failed",
+        expect_partial=False,
+    ),
+    TestCase(
+        name="V3 accept partial with object details remains generic",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=(
+            f'{{"error":"line protocol parsing error","data":'
+            f'{{"error_message":"{LINE_ERROR}","line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}}}'
+        ),
+        accept_partial=True,
+        expected_msg=f"line protocol parsing error:\n\tline 2: {LINE_ERROR} ({REJECTED_LINE})",
+        expect_partial=False,
+    ),
+    TestCase(
+        name="V3 reject partial with object details",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=(
+            f'{{"error":"line protocol parsing error","data":'
+            f'{{"error_message":"{LINE_ERROR}","line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}}}'
+        ),
+        accept_partial=False,
+        expected_msg=f"line protocol parsing error:\n\tline 2: {LINE_ERROR} ({REJECTED_LINE})",
+        expect_partial=False,
+    ),
+    TestCase(
+        name="V2 never returns partial write error",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body=(
+            f'{{"error":"partial write of line protocol occurred","data":['
+            f'{{"error_message":"{LINE_ERROR}","line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}'
+            f"]}}"
+        ),
+        use_v2_api=True,
+        accept_partial=True,
+        expected_msg="partial write of line protocol occurred",
+        expect_partial=False,
+    ),
+    TestCase(
+        name="V3 non-400 never returns partial write error",
+        status_code=http.client.INTERNAL_SERVER_ERROR,
+        content_type="application/json",
+        response_body=(
+            f'{{"error":"partial write of line protocol occurred","data":['
+            f'{{"error_message":"{LINE_ERROR}","line_number":2,"original_line":"{REJECTED_LINE_JSON}"}}'
+            f"]}}"
+        ),
+        accept_partial=True,
+        expected_msg="partial write of line protocol occurred",
+        expect_partial=False,
+    ),
+    TestCase(
+        name="V3 scalar data remains generic",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body='{"error":"write failed","data":"invalid"}',
+        accept_partial=True,
+        expected_msg="write failed",
+        expect_partial=False,
+    ),
+    TestCase(
+        name="V3 empty object data remains generic",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body='{"error":"write failed","data":{}}',
+        accept_partial=True,
+        expected_msg="write failed",
+        expect_partial=False,
+    ),
+    TestCase(
+        name="V3 null data remains generic",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body='{"error":"write failed","data":null}',
+        accept_partial=True,
+        expected_msg="write failed",
+        expect_partial=False,
+    ),
+    TestCase(
+        name="V3 malformed JSON preserves raw response",
+        status_code=http.client.BAD_REQUEST,
+        content_type="application/json",
+        response_body='{"error":"write failed"',
+        accept_partial=True,
+        expected_msg='{"error":"write failed"',
+        expect_partial=False,
+    ),
+]
 
 
 class WriteApiTests(unittest.TestCase):
@@ -29,18 +300,22 @@ class WriteApiTests(unittest.TestCase):
 
         return response.HTTPResponse(status=200, version=4, reason="OK", decode_content=False, request_url=url)
 
-    def _test_api_error(self, body):
+    def _test_api_error(self, body, header=None, accept_partial=None, use_v2_api=None):
         client = InfluxDBClient3(
             host='http://localhost:8181',
             token='my-token',
             database='my-bucket',
             org='my-org'
         )
+        if body is not None:
+            body = body.encode()
+
         client._write_api.rest_client.pool_manager.request \
             = mock.Mock(return_value=response.HTTPResponse(status=400,
+                                                           headers=header or {},
                                                            reason='Bad Request',
-                                                           body=body.encode()))
-        client._write_api.write(record="data,foo=bar val=3.14")
+                                                           body=body))
+        client._write_api.write(record="data,foo=bar val=3.14", accept_partial=accept_partial, use_v2_api=use_v2_api)
 
     def test_default_headers(self):
         client = InfluxDBClient3(
@@ -231,6 +506,8 @@ class WriteApiTests(unittest.TestCase):
                 "\tline 3: invalid column type for column 'v', expected iox::column_type::field::float, "
                 "got iox::column_type::field::uinteger (***.INF.remote_***)",
                 True,
+                False,
+                1
             ),
             # error_message only (no line_number/original_line)
             (
@@ -240,6 +517,8 @@ class WriteApiTests(unittest.TestCase):
                 "partial write of line protocol occurred:\n"
                 "\tonly error message",
                 True,
+                False,
+                1
             ),
             # non-dict item in data list is skipped
             (
@@ -247,8 +526,10 @@ class WriteApiTests(unittest.TestCase):
                 '{"error":"partial write of line protocol occurred","data":[null,'
                 '{"error_message":"bad line","line_number":2,"original_line":"bad lp"}]}',
                 "partial write of line protocol occurred:\n"
-                "\tline 2: bad line (bad lp)",
+                "\t{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"}",
                 True,
+                False,
+                1
             ),
             # details empty -> return error_text
             (
@@ -256,7 +537,9 @@ class WriteApiTests(unittest.TestCase):
                 '{"error":"partial write of line protocol occurred","data":[{"line_number":2}]}',
                 "partial write of line protocol occurred:\n"
                 "\t{\"line_number\":2}",
+                True,
                 False,
+                0
             ),
             # typed parse fails due line_number type -> raw fallback details
             (
@@ -265,7 +548,9 @@ class WriteApiTests(unittest.TestCase):
                 '[{"error_message":"bad line","line_number":"x","original_line":"bad lp"}]}',
                 "partial write of line protocol occurred:\n"
                 "\t{\"error_message\":\"bad line\",\"line_number\":\"x\",\"original_line\":\"bad lp\"}",
+                True,
                 False,
+                0
             ),
             # mixed valid + malformed in array -> raw fallback for whole array
             (
@@ -275,7 +560,9 @@ class WriteApiTests(unittest.TestCase):
                 "partial write of line protocol occurred:\n"
                 "\t{\"error_message\":\"bad line\",\"line_number\":2,\"original_line\":\"bad lp\"}\n"
                 "\t1",
+                True,
                 False,
+                1
             ),
             # data is not a dict when resolving fallback keys
             (
@@ -283,14 +570,18 @@ class WriteApiTests(unittest.TestCase):
                 '{"error":"data not list","data":"oops"}',
                 "data not list",
                 False,
+                True,
+                0
             ),
             # typed object with empty message is dropped
             (
                 "empty error_message in object",
-                '{"error":"partial write of line protocol occurred","data":'
+                '{"error":"parsing failed for write_lp endpoint","data":'
                 '{"error_message":"","line_number":2,"original_line":"bad lp"}}',
-                "partial write of line protocol occurred",
+                "parsing failed for write_lp endpoint",
                 False,
+                True,
+                0
             ),
             # typed array parse fails, raw fallback skips null item
             (
@@ -299,64 +590,87 @@ class WriteApiTests(unittest.TestCase):
                 '[null,{"error_message":123}]}',
                 "partial write of line protocol occurred:\n"
                 "\t{\"error_message\":123}",
+                True,
                 False,
+                1
             ),
         ]
-        for name, response_body, expected, is_partial in cases:
+        for name, response_body, expected, is_partial, use_v2_api, expected_line_error_count in cases:
             with self.subTest(name):
-                with self.assertRaises(InfluxDBError) as err:
-                    self._test_api_error(response_body)
-                self.assertEqual(expected, err.exception.message)
                 if is_partial:
+                    with self.assertRaises(InfluxDBPartialWriteError) as err:
+                        self._test_api_error(body=response_body, accept_partial=is_partial, use_v2_api=use_v2_api)
                     self.assertIsInstance(err.exception, InfluxDBPartialWriteError)
-                    self.assertGreaterEqual(len(err.exception.line_errors), 1)
+                    self.assertGreaterEqual(len(err.exception.line_errors), expected_line_error_count)
                 else:
-                    self.assertNotIsInstance(err.exception, InfluxDBPartialWriteError)
+                    with self.assertRaises(ApiException) as err:
+                        self._test_api_error(body=response_body, accept_partial=is_partial, use_v2_api=use_v2_api)
+                self.assertEqual(expected, err.exception.message)
 
-    def test_api_error_v3_parsing_failed_object_returns_partial_error(self):
+    def test_api_error_v3_parsing_failed_object_returns_error(self):
         response_body = ('{"error":"parsing failed for write_lp endpoint","data":'
                          '{"error_message":"invalid field value","line_number":2,"original_line":"m,t=a f=bad"}}')
-        with self.assertRaises(InfluxDBPartialWriteError) as err:
+        with self.assertRaises(ApiException) as err:
             self._test_api_error(response_body)
-        self.assertEqual(1, len(err.exception.line_errors))
-        self.assertEqual(2, err.exception.line_errors[0].line_number)
-
-    def test_api_error_v3_partial_write_with_message_only_object_returns_partial_error(self):
-        response_body = ('{"error":"partial write of line protocol occurred","data":'
-                         '{"error_message":"only error message"}}')
-        with self.assertRaises(InfluxDBPartialWriteError) as err:
-            self._test_api_error(response_body)
-        self.assertEqual(1, len(err.exception.line_errors))
-        self.assertEqual(0, err.exception.line_errors[0].line_number)
-        self.assertEqual("", err.exception.line_errors[0].original_line)
-
-    def test_api_error_v3_partial_write_with_line_number_without_original_line(self):
-        response_body = ('{"error":"partial write of line protocol occurred","data":'
-                         '{"error_message":"invalid field value","line_number":2}}')
-        with self.assertRaises(InfluxDBPartialWriteError) as err:
-            self._test_api_error(response_body)
-        self.assertEqual(1, len(err.exception.line_errors))
-        self.assertEqual("partial write of line protocol occurred:\n\tline 2: invalid field value",
+        self.assertEqual('parsing failed for write_lp endpoint:\n\tline 2: invalid field value (m,t=a f=bad)',
                          err.exception.message)
 
-    def test_partial_write_from_response_guards(self):
-        self.assertIsNone(InfluxDBPartialWriteError.from_response(None))
+    def test_api_error_v3_write_with_message_only_object_returns(self):
+        response_body = ('{"error":"parsing failed for write_lp endpoint","data":'
+                         '{"error_message":"only error message"}}')
+        with self.assertRaises(ApiException) as err:
+            self._test_api_error(response_body)
+        self.assertEqual("parsing failed for write_lp endpoint:\n\tonly error message", err.exception.message)
 
-        empty_body = response.HTTPResponse(status=400, reason="Bad Request", body=b"")
-        self.assertIsNone(InfluxDBPartialWriteError.from_response(empty_body))
+    def test_api_error_v3_write_with_line_number_without_original_line(self):
+        response_body = ('{"error":"parsing failed for write_lp endpoint","data":'
+                         '{"error_message":"invalid field value","line_number":2}}')
+        with self.assertRaises(ApiException) as err:
+            self._test_api_error(response_body)
+        self.assertEqual("parsing failed for write_lp endpoint:\n\tline 2: invalid field value",
+                         err.exception.message)
 
-        invalid_json = response.HTTPResponse(status=400, reason="Bad Request", body=b"{")
-        self.assertIsNone(InfluxDBPartialWriteError.from_response(invalid_json))
+    def test_api_error_v3_write_with_invalid_line_number(self):
+        response_body = ('{"error":"parsing failed for write_lp endpoint","data":'
+                         '{"error_message":"bad line","line_number":"aa"}}')
+        with self.assertRaises(ApiException) as err:
+            self._test_api_error(response_body)
+        self.assertEqual("parsing failed for write_lp endpoint:\n\tbad line",
+                         err.exception.message)
 
-        non_dict_json = response.HTTPResponse(status=400, reason="Bad Request", body=b"[]")
-        self.assertIsNone(InfluxDBPartialWriteError.from_response(non_dict_json))
+    def test_fallback_header_or_body(self):
+        for body in ["{err", "[]", "{}"]:
+            for is_partial_write in [False, True]:
+                # Fallback to header message
+                with self.assertRaises(InfluxDBError) as err:
+                    header = {"X-Influx-Error": "not used"}
+                    self._test_api_error(
+                        body=body,
+                        header=header,
+                        accept_partial=is_partial_write,
+                        use_v2_api=False
+                    )
+                self.assertEqual(header["X-Influx-Error"], err.exception.message)
 
-        object_without_typed_line_error = response.HTTPResponse(
-            status=400,
-            reason="Bad Request",
-            body=b'{"error":"partial write of line protocol occurred","data":{"error_message":123}}',
-        )
-        self.assertIsNone(InfluxDBPartialWriteError.from_response(object_without_typed_line_error))
+                # Fallback to raw body
+                with self.assertRaises(InfluxDBError) as err:
+                    self._test_api_error(
+                        body=body,
+                        accept_partial=is_partial_write,
+                        use_v2_api=False
+                    )
+                self.assertEqual(body, err.exception.message)
+
+    def test_fallback_status_code_msg(self):
+        for body in ["", None]:
+            for is_partial_write in [False, True]:
+                with self.assertRaises(InfluxDBError) as err:
+                    self._test_api_error(
+                        body=body,
+                        accept_partial=is_partial_write,
+                        use_v2_api=False
+                    )
+                self.assertEqual('Bad Request', err.exception.message)
 
     def test_api_error_headers(self):
         body = '{"error": "test error"}'
@@ -466,6 +780,7 @@ class WriteApiTests(unittest.TestCase):
             (
                 "v2 on v3-only backend",
                 True,
+                False,
                 response.HTTPResponse(status=405, reason="Method Not Allowed", body=b""),
                 ApiException,
                 "Server doesn't support the V2 API endpoint (/api/v2/write). "
@@ -473,6 +788,7 @@ class WriteApiTests(unittest.TestCase):
             ),
             (
                 "v3 on v2-only backend",
+                False,
                 False,
                 response.HTTPResponse(status=405, reason="Method Not Allowed", body=b""),
                 ApiException,
@@ -482,6 +798,7 @@ class WriteApiTests(unittest.TestCase):
             (
                 "v3 partial write response",
                 False,
+                True,
                 response.HTTPResponse(
                     status=400,
                     reason="Bad Request",
@@ -494,7 +811,7 @@ class WriteApiTests(unittest.TestCase):
                 None,
             ),
         ]
-        for name, use_v2_api, http_resp, expected_type, expected_message in cases:
+        for name, use_v2_api, accept_partial, http_resp, expected_type, expected_message in cases:
             with self.subTest(name):
                 client = InfluxDBClient3(
                     host='http://localhost:8181',
@@ -511,7 +828,7 @@ class WriteApiTests(unittest.TestCase):
                     bucket="TEST_BUCKET",
                     body="home,room=Sunroom temp=96 1735545600",
                     precision='s',
-                    accept_partial=False,
+                    accept_partial=accept_partial,
                     no_sync=False,
                     async_req=True,
                     _async_req=True,
@@ -633,3 +950,122 @@ class WriteApiTests(unittest.TestCase):
         expected = ("Server doesn't support the V3 API endpoint (/api/v3/write_lp). "
                     "Set use_v2_api=True to use the V2 API endpoint.")
         self.assertEqual(expected, err.exception.message)
+
+    def test_write_error_classification(self):
+        for tc in TEST_CASES:
+            with self.subTest(tc.name):
+                headers = {"Content-Type": tc.content_type} if tc.content_type is not None else {}
+
+                client = InfluxDBClient3(
+                    host="http://localhost:8086",
+                    token="token",
+                    database="database",
+                )
+                client._write_api.rest_client.pool_manager.request = mock.Mock(
+                    return_value=response.HTTPResponse(
+                        status=tc.status_code,
+                        headers=headers,
+                        body=tc.response_body.encode("utf-8"),
+                    )
+                )
+
+                expected_exc = InfluxDBPartialWriteError if tc.expect_partial else InfluxDBError
+                with self.assertRaises(expected_exc) as cm:
+                    client.write(
+                        record=POINTS,
+                        use_v2_api=tc.use_v2_api,
+                        accept_partial=tc.accept_partial,
+                    )
+
+                err = cm.exception
+                self.assertEqual(tc.expected_msg, err.message)
+                if tc.expect_partial:
+                    self.assertEqual(tc.expected_lines, err.line_errors)
+
+    def test_increment_with_response(self):
+        callback = mock.MagicMock()
+        retry = WritesRetry(total=3, retry_callback=callback)
+
+        mock_response = response.HTTPResponse(
+            body=b'{"code": "unavailable", "message": "service unavailable"}',
+            status=503,
+            headers={"Retry-After": "5"}
+        )
+
+        new_retry = retry.increment(
+            method="POST",
+            url="http://localhost:8086/api/v2/write",
+            response=mock_response
+        )
+
+        self.assertEqual(new_retry.total, 2)
+        self.assertEqual(len(new_retry.history), 1)
+
+        callback.assert_called_once()
+        called_arg = callback.call_args[0][0]
+        self.assertIsInstance(called_arg, InfluxDBError)
+        self.assertEqual(called_arg.response, mock_response)
+
+    def test_increment_with_error(self):
+        callback = mock.MagicMock()
+        retry = WritesRetry(total=3, retry_callback=callback)
+
+        err = ProtocolError("Connection reset by peer")
+        with self.assertRaises(ProtocolError) as e:
+            retry.increment(
+                method="POST",
+                url="http://localhost:8086/api/v2/write",
+                error=err
+            )
+        self.assertEqual(str(e.exception), 'Connection reset by peer')
+
+    def test_increment_with_no_response_and_no_error(self):
+        callback = mock.MagicMock()
+        retry = WritesRetry(total=3, retry_callback=callback)
+
+        url = "http://localhost:8086/api/v2/write"
+        new_retry = retry.increment(method="POST", url=url)
+
+        self.assertEqual(new_retry.total, 2)
+        callback.assert_called_once_with(f'Failed request to: {url}')
+
+    def test_translate_exception_ssl_error(self):
+        ssl_error = SSLError("certificate verify failed: self-signed certificate")
+        msg = "{0}\n{1}".format(type(ssl_error).__name__, str(ssl_error))
+
+        e = translate_write_exception(ApiException(status=0, reason=msg))
+        self.assertIsInstance(e, ApiException)
+        self.assertEqual(e.reason, msg)
+        self.assertEqual(e.status, 0)
+
+    def test_is_partial_write_error(self):
+        valid_root = {"error": "partial write of line protocol occurred", "data": [{"line": 1}]}
+
+        # Positive cases
+        self.assertTrue(is_partial_write_error(http.HTTPStatus.BAD_REQUEST, False, True, valid_root))
+
+        # Negative status codes
+        for status in [200, 204, 401, 403, 404, 500, None]:
+            with self.subTest(status=status):
+                self.assertFalse(is_partial_write_error(status, False, True, valid_root))
+
+        with self.subTest(use_v2_api=True):
+            self.assertFalse(is_partial_write_error(400, True, True, valid_root))
+
+        with self.subTest(accept_partial=False):
+            self.assertFalse(is_partial_write_error(400, False, False, valid_root))
+
+        # Negative root shapes
+        invalid_roots = [
+            {},
+            {"error": None, "data": [{"line": 1}]},
+            {"data": [{"line": 1}]},
+            {"error": "some error"},
+            {"error": "some error", "data": []},
+            {"error": "some error", "data": None},
+            {"error": "some error", "data": "invalid"},
+            {"error": "some error", "data": {"line": 1}},
+        ]
+        for root in invalid_roots:
+            with self.subTest(root=root):
+                self.assertFalse(is_partial_write_error(400, False, True, root))


### PR DESCRIPTION
Closes #

## Proposed Changes

The current exception classes hierarchy are `InfluxDBError` -> `InfluxDBPartialWriteError` and `ApiException`
- In `InfluxDBError` there is an important function `_get_message(self, response)` , this function will run everytime a subclass of `InfluxDBError` is initialized, inside this function there is a quite heavy function will run, that is `_parse_partial_write_line_error_info(data)`, so when a partial write error occurs  `_get_message(self, response)` will be called at least twice.
Some issues:
- With the current implementation it is quite hard to make exception classes run efficiently when a partial writes error occurs.
- Exception class should not have any logic that can affect other exceptions. Exception classes should just some simple data carrier objects with very limited functionality as mine knowledge, or at least this is what I have seen on other v3 clients.
- json.loads(response.data) was called multiple times like in Java v3.
- The assumption that every subclass of `InfluxDBError` will have the same way of parsing the error messages like we do in `_get_message(self, response)` function is not correct... I think.
We can try to make everything work more efficiently as possible with the current exception classes implementation, but I still feel It very wrong on the architecture and design perspective.

What I'm trying to do right now is moving all logic inside exception classes to WriteApi class (or wherever than inside exception classes) and making them as lightweight as possible. They should only carry information about the errors; 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
