### PR TITLE
fix: harden MultiprocessingWriter shutdown and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 1. [#237](https://github.com/InfluxCommunity/influxdb3-python/pull/237): Makes the writing API simpler and more consistent with other v3 clients:
     - Further simplifies the `WriteApi` request path by constructing v2/v3 requests directly through `RestClient`, while preserving existing write behavior.
+1. [#241](https://github.com/InfluxCommunity/influxdb3-python/pull/241): Harden `MultiprocessingWriter` shutdown and error handling:
+    - Replaces assertion-based runtime state validation with explicit exceptions.
+    - Guarantees queue task completion when worker writes fail.
+    - Adds idempotent `close()` with bounded worker shutdown and a configurable `close_timeout`.
+    - Ensures `on_shutdown` is invoked at most once.
 
 ## 0.21.0 [2026-08-27]
 

--- a/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
+++ b/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
@@ -6,6 +6,7 @@ For more information how the multiprocessing works see Python's
 """
 import logging
 import multiprocessing
+import os
 import queue
 
 from influxdb_client_3 import write_client_options
@@ -118,8 +119,6 @@ class MultiprocessingWriter:
 
     """
 
-    __started__ = False
-
     def __init__(self,
                  start_method='spawn',
                  process_ttl=300,
@@ -168,6 +167,9 @@ class MultiprocessingWriter:
         self.ctx = multiprocessing.get_context(start_method)
         self.on_shutdown = on_shutdown
         self.disposed = self.ctx.Value('i', 0)
+        self._shutdown_called = self.ctx.Value('i', 0)
+        self.__started__ = False
+        self._closed = False
         self.process = self.ctx.Process(target=self.run, args=(write_api, self.disposed, process_ttl, self.on_shutdown))
         self.kwargs = kwargs
         self.queue_ = self.ctx.JoinableQueue()
@@ -181,11 +183,35 @@ class MultiprocessingWriter:
         :param kwargs: arguments are passed into the `` write `` function of ``WriteApi``
         :return: None
         """
-        assert self.__started__ is True, 'Cannot write data: the writer is not started.'
-        if self.disposed.value == 0:
-            self.queue_.put(kwargs)
-        else:
-            raise Exception('Cannot write data: the writer is closed.')
+        if self.disposed.value != 0 or self._closed:
+            raise RuntimeError('Cannot write data: the writer is closed.')
+        if not self.__started__:
+            raise RuntimeError('Cannot write data: the writer is not started.')
+        self.queue_.put(kwargs)
+
+    def _call_on_shutdown(self, callback=None) -> None:
+        """Invoke the shutdown callback once across the parent and worker processes."""
+        callback = self.on_shutdown if callback is None else callback
+        if callback is None:
+            return
+
+        with self._shutdown_called.get_lock():
+            if self._shutdown_called.value != 0:
+                return
+            self._shutdown_called.value = 1
+
+        try:
+            callback()
+        except Exception:
+            logger.exception("The multiprocessing writer shutdown callback failed")
+
+    @staticmethod
+    def _close_write_api(write_api: WriteApi) -> None:
+        """Close the worker's WriteApi without preventing process shutdown."""
+        try:
+            write_api.close()
+        except Exception:
+            logger.exception("The multiprocessing writer failed to close the WriteApi")
 
     def run(self, write_api: WriteApi, disposed, process_ttl, on_shutdown) -> None:
         """
@@ -211,24 +237,32 @@ class MultiprocessingWriter:
                 next_record = self.queue_.get(timeout=process_ttl)
             except queue.Empty:
                 if disposed.value == 0:
-                    write_api.close()
+                    self._close_write_api(write_api)
                     disposed.value = 1
-                    if on_shutdown is not None:
-                        on_shutdown()
+                    self._call_on_shutdown(on_shutdown)
+                break
+
+            try:
+                if type(next_record) is _PoisonPill:
+                    # Poison pill means break the loop
+                    logger.info("flushing data...")
+                    self._close_write_api(write_api)
+                    logger.info("closed")
                     break
 
-            if type(next_record) is _PoisonPill:
-                # Poison pill means break the loop
-                logger.info("flushing data...")
-                write_api.close()
-                logger.info("closed")
+                try:
+                    write_api.write(**next_record)
+                except Exception:
+                    logger.exception("The multiprocessing writer failed to write a record")
+            finally:
                 self.queue_.task_done()
-                break
-            write_api.write(**next_record)
-            self.queue_.task_done()
 
     def start(self) -> None:
         """Start an independent process for writing data into InfluxDB."""
+        if self._closed or self.disposed.value != 0:
+            raise RuntimeError('Cannot start the writer after it has been closed.')
+        if self.__started__:
+            raise RuntimeError('The writer is already started.')
         self.process.start()
         self.__started__ = True
 
@@ -242,16 +276,29 @@ class MultiprocessingWriter:
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Exit the runtime context related to this object."""
-        self.__del__()
+        self.close()
+
+    def close(self) -> None:
+        """Flush queued writes and close the worker process once."""
+        if self._closed:
+            return
+
+        self._closed = True
+        is_worker_process = getattr(self.process, 'pid', None) == os.getpid()
+        try:
+            if self.__started__ and not is_worker_process:
+                if self.disposed.value == 0:
+                    self.queue_.put(_PoisonPill())
+                self.process.join()
+        finally:
+            self.__started__ = False
+            self.disposed.value = 1
+            if not is_worker_process:
+                self._call_on_shutdown()
 
     def __del__(self):
-        """Dispose of the client and write_api."""
-        if self.__started__ and self.disposed.value == 0:
-            self.queue_.put(_PoisonPill())
-            self.queue_.join()
-            self.process.join()
-            self.queue_ = None
-        self.__started__ = False
-        self.disposed.value = 1
-        if self.on_shutdown is not None:
-            self.on_shutdown()
+        """Best-effort cleanup for writers that were not explicitly closed."""
+        try:
+            self.close()
+        except Exception:
+            logger.debug("The multiprocessing writer cleanup failed", exc_info=True)

--- a/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
+++ b/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
@@ -123,6 +123,7 @@ class MultiprocessingWriter:
                  start_method='spawn',
                  process_ttl=300,
                  on_shutdown=None,
+                 close_timeout=60,
                  **kwargs
                  ) -> None:
         """
@@ -135,6 +136,7 @@ class MultiprocessingWriter:
         :param process_ttl: The timeout in seconds for waiting for data in the underlying queue.
         :param on_shutdown: The callback function called when the worker process is shut down
                or when `MultiprocessingWriter` class start closing.
+        :param close_timeout: The timeout in seconds for waiting for the worker to shut down gracefully.
         :param kwargs: Arguments are passed into the ``WriteApi`` and ``write_client_options``.
             Common arguments include: `host`, `token`, `database`, `org`, `write_options`, `success_callback`,
             `error_callback`, `retry_callback`, `default_header`, and `rest_client`.
@@ -166,6 +168,7 @@ class MultiprocessingWriter:
 
         self.ctx = multiprocessing.get_context(start_method)
         self.on_shutdown = on_shutdown
+        self.close_timeout = close_timeout
         self.disposed = self.ctx.Value('i', 0)
         self._shutdown_called = self.ctx.Value('i', 0)
         self.__started__ = False
@@ -289,7 +292,11 @@ class MultiprocessingWriter:
             if self.__started__ and not is_worker_process:
                 if self.disposed.value == 0:
                     self.queue_.put(_PoisonPill())
-                self.process.join()
+                self.process.join(timeout=self.close_timeout)
+                if self.process.is_alive():
+                    logger.warning("The multiprocessing writer worker did not shut down before the timeout")
+                    self.process.terminate()
+                    self.process.join(timeout=self.close_timeout)
         finally:
             self.__started__ = False
             self.disposed.value = 1

--- a/tests/test_multiprocessing_helper.py
+++ b/tests/test_multiprocessing_helper.py
@@ -9,7 +9,7 @@ from influxdb_client_3.write_client.client.util.multiprocessing_helper import Mu
 
 def make_writer(**kwargs):
     return MultiprocessingWriter(
-        start_method="fork",
+        start_method="spawn",
         host="http://localhost:8086",
         database="test",
         rest_client=Mock(),

--- a/tests/test_multiprocessing_helper.py
+++ b/tests/test_multiprocessing_helper.py
@@ -1,9 +1,10 @@
+import logging
 import queue
 from unittest.mock import Mock
 
 import pytest
 
-from influxdb_client_3.write_client.client.util.multiprocessing_helper import MultiprocessingWriter
+from influxdb_client_3.write_client.client.util.multiprocessing_helper import MultiprocessingWriter, _PoisonPill
 
 
 def make_writer(**kwargs):
@@ -17,8 +18,9 @@ def make_writer(**kwargs):
 
 
 class RecordingWriteApi:
-    def __init__(self, error=None):
+    def __init__(self, error=None, close_error=None):
         self.error = error
+        self.close_error = close_error
         self.writes = []
         self.close_calls = 0
 
@@ -29,6 +31,8 @@ class RecordingWriteApi:
 
     def close(self):
         self.close_calls += 1
+        if self.close_error is not None:
+            raise self.close_error
 
 
 class FakeProcess:
@@ -85,6 +89,38 @@ def test_write_after_close_raises_runtime_error():
         writer.write(record="value")
 
 
+def test_write_after_start_queues_record():
+    writer = make_writer()
+    writer.process = FakeProcess()
+    writer.queue_ = FakeQueue()
+    writer.start()
+    writer.write(record="value")
+
+    assert writer.queue_.items == [{"record": "value"}]
+
+
+def test_start_after_close_raises_runtime_error():
+    writer = make_writer()
+    writer.close()
+
+    with pytest.raises(RuntimeError, match="after it has been closed"):
+        writer.start()
+
+
+def test_start_twice_raises_runtime_error():
+    writer = make_writer()
+    writer.process = FakeProcess()
+    writer.queue_ = FakeQueue()
+    writer.start()
+
+    with pytest.raises(RuntimeError, match="already started"):
+        writer.start()
+
+
+def test_get_start_processing_method_returns_context_method():
+    assert make_writer().get_start_processing_method() == "fork"
+
+
 def test_worker_timeout_closes_api_and_invokes_callback_once():
     writer = make_writer(process_ttl=0.01)
     writer.queue_ = Mock()
@@ -100,6 +136,48 @@ def test_worker_timeout_closes_api_and_invokes_callback_once():
     on_shutdown.assert_called_once_with()
     with pytest.raises(RuntimeError, match="writer is closed"):
         writer.write(record="after-timeout")
+
+
+def test_worker_timeout_continues_when_write_api_close_fails():
+    writer = make_writer()
+    writer.queue_ = Mock()
+    writer.queue_.get.side_effect = queue.Empty
+    write_api = RecordingWriteApi(close_error=ValueError("close failed"))
+
+    writer.run(write_api, writer.disposed, 0.01, None)
+
+    assert writer.disposed.value == 1
+    assert write_api.close_calls == 1
+
+
+def test_worker_poison_pill_closes_write_api():
+    writer = make_writer()
+    writer.queue_.put(_PoisonPill())
+    write_api = RecordingWriteApi()
+
+    writer.run(write_api, writer.disposed, 0.01, None)
+    writer.queue_.join()
+
+    assert write_api.close_calls == 1
+
+
+def test_shutdown_callback_is_called_once_when_invoked_repeatedly():
+    writer = make_writer()
+    callback = Mock()
+
+    writer._call_on_shutdown(callback)
+    writer._call_on_shutdown(callback)
+
+    callback.assert_called_once_with()
+
+
+def test_shutdown_callback_failure_is_logged(caplog):
+    writer = make_writer()
+    callback = Mock(side_effect=ValueError("callback failed"))
+
+    writer._call_on_shutdown(callback)
+
+    assert "shutdown callback failed" in caplog.text
 
 
 def test_worker_write_failure_marks_queue_item_done():
@@ -148,3 +226,13 @@ def test_context_manager_uses_close():
 
     writer.start.assert_called_once_with()
     writer.close.assert_called_once_with()
+
+
+def test_destructor_swallows_cleanup_failure(caplog):
+    caplog.set_level(logging.DEBUG)
+    writer = make_writer()
+    writer.close = Mock(side_effect=RuntimeError("cleanup failed"))
+
+    writer.__del__()
+
+    assert "cleanup failed" in caplog.text

--- a/tests/test_multiprocessing_helper.py
+++ b/tests/test_multiprocessing_helper.py
@@ -1,0 +1,120 @@
+import queue
+from unittest.mock import Mock
+
+import pytest
+
+from influxdb_client_3.write_client.client.util.multiprocessing_helper import MultiprocessingWriter
+
+
+def make_writer(**kwargs):
+    return MultiprocessingWriter(
+        start_method="fork",
+        host="http://localhost:8086",
+        database="test",
+        rest_client=Mock(),
+        **kwargs,
+    )
+
+
+class RecordingWriteApi:
+    def __init__(self, error=None):
+        self.error = error
+        self.writes = []
+        self.close_calls = 0
+
+    def write(self, **record):
+        self.writes.append(record)
+        if self.error is not None:
+            raise self.error
+
+    def close(self):
+        self.close_calls += 1
+
+
+class FakeProcess:
+    def __init__(self):
+        self.start_calls = 0
+        self.join_calls = 0
+
+    def start(self):
+        self.start_calls += 1
+
+    def join(self):
+        self.join_calls += 1
+
+
+class FakeQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+def test_write_before_start_raises_runtime_error():
+    writer = make_writer()
+
+    with pytest.raises(RuntimeError, match="writer is not started"):
+        writer.write(record="value")
+
+
+def test_write_after_close_raises_runtime_error():
+    writer = make_writer()
+    writer.close()
+
+    with pytest.raises(RuntimeError, match="writer is closed"):
+        writer.write(record="value")
+
+
+def test_worker_timeout_closes_api_and_invokes_callback_once():
+    writer = make_writer(process_ttl=0.01)
+    writer.queue_ = Mock()
+    writer.queue_.get.side_effect = queue.Empty
+    write_api = RecordingWriteApi()
+    on_shutdown = Mock()
+
+    writer.run(write_api, writer.disposed, 0.01, on_shutdown)
+    writer.close()
+
+    assert writer.disposed.value == 1
+    assert write_api.close_calls == 1
+    on_shutdown.assert_called_once_with()
+    with pytest.raises(RuntimeError, match="writer is closed"):
+        writer.write(record="after-timeout")
+
+
+def test_worker_write_failure_marks_queue_item_done():
+    writer = make_writer()
+    writer.queue_.put({"record": "value"})
+    write_api = RecordingWriteApi(error=ValueError("write failed"))
+
+    writer.run(write_api, writer.disposed, 0.01, None)
+    writer.queue_.join()
+
+    assert write_api.writes == [{"record": "value"}]
+    assert writer.disposed.value == 1
+
+
+def test_close_is_idempotent_and_sends_one_poison_pill():
+    writer = make_writer()
+    writer.process = FakeProcess()
+    writer.queue_ = FakeQueue()
+    writer.start()
+    writer.close()
+    writer.close()
+
+    assert writer.process.start_calls == 1
+    assert writer.process.join_calls == 1
+    assert len(writer.queue_.items) == 1
+
+
+def test_context_manager_uses_close():
+    writer = make_writer()
+    writer.start = Mock()
+    writer.close = Mock()
+
+    writer.__enter__()
+    writer.__exit__(None, None, None)
+
+    writer.start.assert_called_once_with()
+    writer.close.assert_called_once_with()

--- a/tests/test_multiprocessing_helper.py
+++ b/tests/test_multiprocessing_helper.py
@@ -118,7 +118,7 @@ def test_start_twice_raises_runtime_error():
 
 
 def test_get_start_processing_method_returns_context_method():
-    assert make_writer().get_start_processing_method() == "fork"
+    assert make_writer().get_start_processing_method() == "spawn"
 
 
 def test_worker_timeout_closes_api_and_invokes_callback_once():

--- a/tests/test_multiprocessing_helper.py
+++ b/tests/test_multiprocessing_helper.py
@@ -1,10 +1,16 @@
 import logging
 import queue
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
-from influxdb_client_3.write_client.client.util.multiprocessing_helper import MultiprocessingWriter, _PoisonPill
+from influxdb_client_3.write_client.client.util.multiprocessing_helper import (
+    MultiprocessingWriter,
+    _PoisonPill,
+    _error_callback,
+    _retry_callback,
+    _success_callback,
+)
 
 
 def make_writer(**kwargs):
@@ -119,6 +125,37 @@ def test_start_twice_raises_runtime_error():
 
 def test_get_start_processing_method_returns_context_method():
     assert make_writer().get_start_processing_method() == "spawn"
+
+
+def test_default_callbacks_log_batch_events(caplog):
+    caplog.set_level(logging.DEBUG)
+    conf = ("database", "org", "precision")
+    exception = ValueError("write failed")
+
+    _success_callback(conf, "data")
+    _error_callback(conf, "data", exception)
+    _retry_callback(conf, "data", exception)
+
+    assert "Written batch" in caplog.text
+    assert "Cannot write batch" in caplog.text
+    assert "Retryable error occurs" in caplog.text
+
+
+def test_constructor_builds_rest_client_from_host_and_token():
+    rest_client_path = "influxdb_client_3.write_client.client.util.multiprocessing_helper.rest_client.RestClient"
+    with patch(rest_client_path) as rest_client:
+        writer = MultiprocessingWriter(
+            start_method="spawn",
+            host="http://localhost:8086",
+            token="my-token",
+            database="test",
+        )
+
+    rest_client.assert_called_once_with(
+        base_url="http://localhost:8086",
+        default_header={"Authorization": "Token my-token"},
+    )
+    writer.close()
 
 
 def test_worker_timeout_closes_api_and_invokes_callback_once():

--- a/tests/test_multiprocessing_helper.py
+++ b/tests/test_multiprocessing_helper.py
@@ -39,8 +39,27 @@ class FakeProcess:
     def start(self):
         self.start_calls += 1
 
-    def join(self):
+    def join(self, timeout=None):
         self.join_calls += 1
+
+    def is_alive(self):
+        return False
+
+
+class HangingProcess(FakeProcess):
+    def __init__(self):
+        super().__init__()
+        self.join_timeouts = []
+        self.terminate_calls = 0
+
+    def join(self, timeout=None):
+        self.join_timeouts.append(timeout)
+
+    def is_alive(self):
+        return True
+
+    def terminate(self):
+        self.terminate_calls += 1
 
 
 class FakeQueue:
@@ -106,6 +125,17 @@ def test_close_is_idempotent_and_sends_one_poison_pill():
     assert writer.process.start_calls == 1
     assert writer.process.join_calls == 1
     assert len(writer.queue_.items) == 1
+
+
+def test_close_terminates_worker_after_join_timeout():
+    writer = make_writer(close_timeout=0.01)
+    writer.process = HangingProcess()
+    writer.queue_ = FakeQueue()
+    writer.start()
+    writer.close()
+
+    assert writer.process.join_timeouts == [0.01, 0.01]
+    assert writer.process.terminate_calls == 1
 
 
 def test_context_manager_uses_close():


### PR DESCRIPTION
Closes #230

## Proposed Changes

Harden `MultiprocessingWriter` lifecycle and worker error handling:

- Replace assertion-based runtime state validation with explicit exceptions.
- Guarantee queue task completion on successful and failed writes.
- Add idempotent `close()` with bounded worker shutdown and configurable `close_timeout`.
- Ensure shutdown callbacks run at most once.
- Add regression coverage for timeout, write failure, poison-pill shutdown, callback failures, and lifecycle validation.
- Document the change in `CHANGELOG.md`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable (blocked while integration CI is pending)
- [x] A test has been added if appropriate
- [x] Tests pass locally
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)