### PR TITLE
fix: remove stale influxdb_client references from v3 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Bug Fixes
 
-1. [#237](https://github.com/InfluxCommunity/influxdb3-python/pull/237): Makes the writing API simpler and more consistent with other v3 clients:
+1. [#242](https://github.com/InfluxCommunity/influxdb3-python/issues/242): Remove stale `influxdb_client` references from v3 docstrings, examples, comments, and logger names.
+
+2. [#237](https://github.com/InfluxCommunity/influxdb3-python/pull/237): Makes the writing API simpler and more consistent with other v3 clients:
     - Further simplifies the `WriteApi` request path by constructing v2/v3 requests directly through `RestClient`, while preserving existing write behavior.
 
 ## 0.21.0 [2026-08-27]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-1. [#242](https://github.com/InfluxCommunity/influxdb3-python/issues/242): Remove stale `influxdb_client` references from v3 docstrings, examples, comments, and logger names.
+1. [#243](https://github.com/InfluxCommunity/influxdb3-python/pull/243): Remove stale `influxdb_client` references from v3 docstrings, examples, comments, and logger names. (Closes #242)
 
 2. [#237](https://github.com/InfluxCommunity/influxdb3-python/pull/237): Makes the writing API simpler and more consistent with other v3 clients:
     - Further simplifies the `WriteApi` request path by constructing v2/v3 requests directly through `RestClient`, while preserving existing write behavior.

--- a/influxdb_client_3/query/query_api.py
+++ b/influxdb_client_3/query/query_api.py
@@ -145,7 +145,7 @@ class QueryApi(object):
 
             # Initialize instance of QueryApi
             with InfluxDBClient3(host="http://localhost:8086", token="my-token", database="my-database") as client:
-                result = client.query("from(bucket: \"my-bucket\") |> range(start: -1h)")
+                result = client.query("SELECT * FROM my_measurement", language="sql")
     """
 
     def __init__(self,

--- a/influxdb_client_3/query/query_api.py
+++ b/influxdb_client_3/query/query_api.py
@@ -140,12 +140,12 @@ class QueryApi(object):
 
         .. code-block:: python
 
-            from influxdb_client import InfluxDBClient
+            from influxdb_client_3 import InfluxDBClient3
 
 
             # Initialize instance of QueryApi
-            with InfluxDBClient(url="http://localhost:8086", token="my-token") as client:
-                query_api = client.query_api()
+            with InfluxDBClient3(host="http://localhost:8086", token="my-token", database="my-database") as client:
+                result = client.query("from(bucket: \"my-bucket\") |> range(start: -1h)")
     """
 
     def __init__(self,

--- a/influxdb_client_3/query/query_api.py
+++ b/influxdb_client_3/query/query_api.py
@@ -143,7 +143,7 @@ class QueryApi(object):
             from influxdb_client_3 import InfluxDBClient3
 
 
-            # Initialize instance of QueryApi
+            # Query data from InfluxDB
             with InfluxDBClient3(host="http://localhost:8086", token="my-token", database="my-database") as client:
                 result = client.query("SELECT * FROM my_measurement", language="sql")
     """

--- a/influxdb_client_3/write_client/_sync/rest_client.py
+++ b/influxdb_client_3/write_client/_sync/rest_client.py
@@ -213,13 +213,13 @@ class RestClient(object):
             if not any(map(lambda h: isinstance(h, logging.StreamHandler) and h.stream == sys.stdout,
                            self.logger.handlers)):
                 self.logger.addHandler(logging.StreamHandler(sys.stdout))
-            # we use 'influxdb_client_3.write_client._sync.rest_client' logger instead of this
+            # HTTP debug logging is handled by the 'influxdb_client_3.write_client._sync.rest_client' logger.
             # httplib.HTTPConnection.debuglevel = 1
         else:
             # if debug status is False, turn off debug logging,
             # setting log level to default `logging.WARNING`
             self.logger.setLevel(logging.WARNING)
-            # we use 'influxdb_client_3.write_client._sync.rest_client' logger instead of this
+            # HTTP debug logging is handled by the 'influxdb_client_3.write_client._sync.rest_client' logger.
             # httplib.HTTPConnection.debuglevel = 0
 
     @staticmethod

--- a/influxdb_client_3/write_client/_sync/rest_client.py
+++ b/influxdb_client_3/write_client/_sync/rest_client.py
@@ -37,7 +37,7 @@ class RESTResponse(io.IOBase):
 
 
 class RestClient(object):
-    logger = logging.getLogger('influxdb_client.client.http')
+    logger = logging.getLogger('influxdb_client_3.write_client._sync.rest_client')
 
     def __init__(self,
                  base_url,
@@ -213,13 +213,13 @@ class RestClient(object):
             if not any(map(lambda h: isinstance(h, logging.StreamHandler) and h.stream == sys.stdout,
                            self.logger.handlers)):
                 self.logger.addHandler(logging.StreamHandler(sys.stdout))
-            # we use 'influxdb_client.client.http' logger instead of this
+            # we use 'influxdb_client_3.write_client._sync.rest_client' logger instead of this
             # httplib.HTTPConnection.debuglevel = 1
         else:
             # if debug status is False, turn off debug logging,
             # setting log level to default `logging.WARNING`
             self.logger.setLevel(logging.WARNING)
-            # we use 'influxdb_client.client.http' logger instead of this
+            # we use 'influxdb_client_3.write_client._sync.rest_client' logger instead of this
             # httplib.HTTPConnection.debuglevel = 0
 
     @staticmethod

--- a/influxdb_client_3/write_client/client/util/date_utils.py
+++ b/influxdb_client_3/write_client/client/util/date_utils.py
@@ -19,8 +19,8 @@ class DateHelper:
 
     .. code-block:: python
 
-        from influxdb_client.client.util import date_utils
-        from influxdb_client.client.util.date_utils import DateHelper
+        from influxdb_client_3.write_client.client.util import date_utils
+        from influxdb_client_3.write_client.client.util.date_utils import DateHelper
         import dateutil.parser
         from dateutil import tz
 

--- a/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
+++ b/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
@@ -13,7 +13,7 @@ from influxdb_client_3.exceptions import InfluxDBError
 from influxdb_client_3.write_client import WriteOptions, WriteApi
 from influxdb_client_3.write_client._sync import rest_client
 
-logger = logging.getLogger('influxdb_client.client.util.multiprocessing_helper')
+logger = logging.getLogger('influxdb_client_3.write_client.client.util.multiprocessing_helper')
 
 
 def _success_callback(conf: (str, str, str), data: str):
@@ -44,8 +44,8 @@ class MultiprocessingWriter:
     Example:
         .. code-block:: python
 
-            from influxdb_client import WriteOptions
-            from influxdb_client.client.util.multiprocessing_helper import MultiprocessingWriter
+            from influxdb_client_3 import WriteOptions
+            from influxdb_client_3.write_client.client.util.multiprocessing_helper import MultiprocessingWriter
 
 
             def main():
@@ -66,8 +66,8 @@ class MultiprocessingWriter:
     How to use with context_manager:
         .. code-block:: python
 
-            from influxdb_client import WriteOptions
-            from influxdb_client.client.util.multiprocessing_helper import MultiprocessingWriter
+            from influxdb_client_3 import WriteOptions
+            from influxdb_client_3.write_client.client.util.multiprocessing_helper import MultiprocessingWriter
 
 
             def main():
@@ -84,9 +84,9 @@ class MultiprocessingWriter:
     How to handle batch events:
         .. code-block:: python
 
-            from influxdb_client import WriteOptions
-            from influxdb_client.client.exceptions import InfluxDBError
-            from influxdb_client.client.util.multiprocessing_helper import MultiprocessingWriter
+            from influxdb_client_3 import WriteOptions
+            from influxdb_client_3.exceptions import InfluxDBError
+            from influxdb_client_3.write_client.client.util.multiprocessing_helper import MultiprocessingWriter
 
 
             class BatchingCallback(object):

--- a/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
+++ b/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
@@ -49,7 +49,8 @@ class MultiprocessingWriter:
 
 
             def main():
-                writer = MultiprocessingWriter(url="http://localhost:8086", token="my-token", org="my-org",
+                writer = MultiprocessingWriter(host="http://localhost:8086", token="my-token", org="my-org",
+                                               database="my-bucket",
                                                write_options=WriteOptions(batch_size=100))
                 writer.start()
 
@@ -71,7 +72,8 @@ class MultiprocessingWriter:
 
 
             def main():
-                with MultiprocessingWriter(url="http://localhost:8086", token="my-token", org="my-org",
+                with MultiprocessingWriter(host="http://localhost:8086", token="my-token", org="my-org",
+                                           database="my-bucket",
                                            write_options=WriteOptions(batch_size=100)) as writer:
                     for x in range(1, 1000):
                         writer.write(bucket="my-bucket", record=f"mem,tag=a value={x}i {x}")
@@ -103,7 +105,8 @@ class MultiprocessingWriter:
 
             def main():
                 callback = BatchingCallback()
-                with MultiprocessingWriter(url="http://localhost:8086", token="my-token", org="my-org",
+                with MultiprocessingWriter(host="http://localhost:8086", token="my-token", org="my-org",
+                                           database="my-bucket",
                                            success_callback=callback.success,
                                            error_callback=callback.error,
                                            retry_callback=callback.retry) as writer:

--- a/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
+++ b/influxdb_client_3/write_client/client/util/multiprocessing_helper.py
@@ -50,12 +50,12 @@ class MultiprocessingWriter:
 
             def main():
                 writer = MultiprocessingWriter(host="http://localhost:8086", token="my-token", org="my-org",
-                                               database="my-bucket",
+                                               database="my-database",
                                                write_options=WriteOptions(batch_size=100))
                 writer.start()
 
                 for x in range(1, 1000):
-                    writer.write(bucket="my-bucket", record=f"mem,tag=a value={x}i {x}")
+                    writer.write(bucket="my-database", record=f"mem,tag=a value={x}i {x}")
 
                 writer.__del__()
 
@@ -73,10 +73,10 @@ class MultiprocessingWriter:
 
             def main():
                 with MultiprocessingWriter(host="http://localhost:8086", token="my-token", org="my-org",
-                                           database="my-bucket",
+                                           database="my-database",
                                            write_options=WriteOptions(batch_size=100)) as writer:
                     for x in range(1, 1000):
-                        writer.write(bucket="my-bucket", record=f"mem,tag=a value={x}i {x}")
+                        writer.write(bucket="my-database", record=f"mem,tag=a value={x}i {x}")
 
 
             if __name__ == '__main__':
@@ -106,13 +106,13 @@ class MultiprocessingWriter:
             def main():
                 callback = BatchingCallback()
                 with MultiprocessingWriter(host="http://localhost:8086", token="my-token", org="my-org",
-                                           database="my-bucket",
+                                           database="my-database",
                                            success_callback=callback.success,
                                            error_callback=callback.error,
                                            retry_callback=callback.retry) as writer:
 
                     for x in range(1, 1000):
-                        writer.write(bucket="my-bucket", record=f"mem,tag=a value={x}i {x}")
+                        writer.write(bucket="my-database", record=f"mem,tag=a value={x}i {x}")
 
 
             if __name__ == '__main__':

--- a/influxdb_client_3/write_client/client/warnings.py
+++ b/influxdb_client_3/write_client/client/warnings.py
@@ -19,7 +19,7 @@ The result will not be shaped to optimal processing by pandas.DataFrame. Use the
 
 You can disable this warning by:
     import warnings
-    from influxdb_client.client.warnings import MissingPivotFunction
+    from influxdb_client_3.write_client.client.warnings import MissingPivotFunction
 
     warnings.simplefilter("ignore", MissingPivotFunction)
 
@@ -45,7 +45,7 @@ For more info see:
 
 You can disable this warning by:
     import warnings
-    from influxdb_client.client.warnings import CloudOnlyWarning
+    from influxdb_client_3.write_client.client.warnings import CloudOnlyWarning
 
     warnings.simplefilter("ignore", CloudOnlyWarning)
 """

--- a/influxdb_client_3/write_client/client/write/dataframe_serializer.py
+++ b/influxdb_client_3/write_client/client/write/dataframe_serializer.py
@@ -12,7 +12,7 @@ from influxdb_client_3.write_client.domain import WritePrecision
 from influxdb_client_3.write_client.client.write.point import _ESCAPE_KEY, _ESCAPE_STRING, _ESCAPE_MEASUREMENT, \
     DEFAULT_WRITE_PRECISION, ordered_tag_keys
 
-logger = logging.getLogger('influxdb_client.client.write.dataframe_serializer')
+logger = logging.getLogger('influxdb_client_3.write_client.client.write.dataframe_serializer')
 
 
 def _not_nan(x):

--- a/influxdb_client_3/write_client/client/write/polars_dataframe_serializer.py
+++ b/influxdb_client_3/write_client/client/write/polars_dataframe_serializer.py
@@ -10,7 +10,7 @@ import math
 from influxdb_client_3.write_client.client.write.point import _ESCAPE_KEY, _ESCAPE_STRING, DEFAULT_WRITE_PRECISION, \
     ordered_tag_keys
 
-logger = logging.getLogger('influxdb_client.client.write.polars_dataframe_serializer')
+logger = logging.getLogger('influxdb_client_3.write_client.client.write.polars_dataframe_serializer')
 
 
 class PolarsDataframeSerializer:

--- a/influxdb_client_3/write_client/client/write/retry.py
+++ b/influxdb_client_3/write_client/client/write/retry.py
@@ -11,7 +11,7 @@ from urllib3.exceptions import MaxRetryError, ResponseError
 
 from influxdb_client_3.exceptions import InfluxDBError
 
-logger = logging.getLogger('influxdb_client.client.write.retry')
+logger = logging.getLogger('influxdb_client_3.write_client.client.write.retry')
 
 
 class WritesRetry(Retry):


### PR DESCRIPTION
Closes #242

## Proposed Changes

Update v3-specific docstrings, embedded examples, comments, and logger names to use canonical `influxdb_client_3` paths. No public API or runtime behavior changes.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)